### PR TITLE
feat(proxy): add GitHub proxy fallback for file downloads

### DIFF
--- a/installer/config.sh
+++ b/installer/config.sh
@@ -14,6 +14,8 @@ TEMP_DIR="/tmp/b4_install_$$"
 QUIET_MODE="0"
 GEOSITE_SRC=""
 GEOSITE_DST=""
+# Proxy configuration for GitHub fallback
+PROXY_BASE_URL="https://proxy.lavrush.in/github"
 
 # geodat sources (pipe-delimited: number|name|url)
 GEODAT_SOURCES="1|Loyalsoldier source|https://github.com/Loyalsoldier/v2ray-rules-dat/releases/latest/download

--- a/installer/utils.sh
+++ b/installer/utils.sh
@@ -159,34 +159,93 @@ stop_process() {
     fi
 }
 
-# Download file from URL
+# Convert GitHub URL to proxy URL
+convert_to_proxy_url() {
+    url="$1"
+    # Check if URL is from allowed GitHub domains
+    case "$url" in
+    https://raw.githubusercontent.com/DanielLavrushin/* | \
+        https://github.com/DanielLavrushin/* | \
+        https://objects.githubusercontent.com/DanielLavrushin/* | \
+        https://codeload.github.com/DanielLavrushin/* | \
+        https://gist.githubusercontent.com/DanielLavrushin/* | \
+        https://api.github.com/repos/DanielLavrushin/*)
+        echo "${PROXY_BASE_URL}/${url}"
+        ;;
+    *)
+        echo "$url"
+        ;;
+    esac
+}
+
+# Download file from URL with GitHub fallback
 fetch_file() {
     url="$1"
     output="$2"
 
+    # Try direct GitHub download first
     if command_exists wget; then
-        wget -q -O "$output" "$url" 2>/dev/null
-        return $?
+        if wget -q --timeout=10 -O "$output" "$url" 2>/dev/null; then
+            return 0
+        fi
     elif command_exists curl; then
-        curl -sfL -o "$output" "$url" 2>/dev/null
-        return $?
+        if curl -sfL --max-time 10 -o "$output" "$url" 2>/dev/null; then
+            return 0
+        fi
     else
         print_error "Neither wget nor curl found"
         return 1
     fi
+
+    # If direct download failed, try proxy fallback
+    proxy_url=$(convert_to_proxy_url "$url")
+    if [ "$proxy_url" != "$url" ]; then
+        print_warning "Direct download failed, trying proxy (proxy.lavrush.in)..."
+        if command_exists wget; then
+            wget -q --timeout=15 -O "$output" "$proxy_url" 2>/dev/null
+            return $?
+        elif command_exists curl; then
+            curl -sfL --max-time 15 -o "$output" "$proxy_url" 2>/dev/null
+            return $?
+        fi
+    fi
+
+    print_error "Failed to download file from $url"
+    return 1
 }
 
-# Fetch URL content to stdout
+# Fetch URL content to stdout with GitHub fallback
 fetch_stdout() {
     url="$1"
 
+    # Try direct GitHub download first
+    result=""
     if command_exists wget; then
-        wget -qO- "$url" 2>/dev/null
+        result=$(wget -qO- --timeout=10 "$url" 2>/dev/null)
     elif command_exists curl; then
-        curl -sfL "$url" 2>/dev/null
+        result=$(curl -sfL --max-time 10 "$url" 2>/dev/null)
     else
         return 1
     fi
+
+    # If direct download succeeded, return result
+    if [ -n "$result" ]; then
+        echo "$result"
+        return 0
+    fi
+
+    # If direct download failed, try proxy fallback
+    proxy_url=$(convert_to_proxy_url "$url")
+    if [ "$proxy_url" != "$url" ]; then
+        if command_exists wget; then
+            wget -qO- --timeout=15 "$proxy_url" 2>/dev/null
+        elif command_exists curl; then
+            curl -sfL --max-time 15 "$proxy_url" 2>/dev/null
+        fi
+        return $?
+    fi
+
+    return 1
 }
 
 detect_pkg_manager() {


### PR DESCRIPTION
This pull request introduces a GitHub proxy fallback mechanism to improve the reliability of file downloads in both the main installer and its supporting scripts. If direct downloads from specific GitHub domains fail (for resources owned by `DanielLavrushin`), the scripts will automatically retry using a proxy service. The changes are applied consistently to both the main installer and the modular installer scripts.

**Proxy Fallback Integration:**

* Added a new `PROXY_BASE_URL` variable to `install.sh` and `installer/config.sh` to configure the proxy endpoint for fallback downloads. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR31-R32) [[2]](diffhunk://#diff-aadf04cbd74fedc4748853ca08d20d8b779ce46309e9cfe9efed70730ecbcbadR17-R18)
* Implemented the `convert_to_proxy_url` function in `install.sh` and `installer/utils.sh` to rewrite eligible GitHub URLs to use the proxy if needed. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL224-R312) [[2]](diffhunk://#diff-170f986a2a0dd168c89e3feabb961ff41dfae2cf1070857d65047f97e75c290cL162-R248)

**Download Logic Enhancements:**

* Updated `fetch_file` and `fetch_stdout` functions in both scripts to first attempt direct downloads, and if they fail, automatically retry using the proxy for eligible URLs. This improves robustness against GitHub download failures. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL224-R312) [[2]](diffhunk://#diff-170f986a2a0dd168c89e3feabb961ff41dfae2cf1070857d65047f97e75c290cL162-R248)

These changes ensure that installer operations are less likely to fail due to GitHub connectivity issues, especially for resources under the `DanielLavrushin` account.