### PR TITLE
feat(fetch): streamline fetch_stdout function for direct download suc…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -283,16 +283,19 @@ fetch_stdout() {
     url="$1"
 
     # Try direct GitHub download first
+    result=""
     if command_exists wget; then
-        result=$(wget -qO- --timeout=10 "$url" 2>/dev/null) && [ -n "$result" ] && {
+        result=$(wget -qO- --timeout=10 "$url" 2>/dev/null)
+        if [ $? -eq 0 ] && [ -n "$result" ]; then
             echo "$result"
             return 0
-        }
+        fi
     elif command_exists curl; then
-        result=$(curl -sfL --max-time 10 "$url" 2>/dev/null) && [ -n "$result" ] && {
+        result=$(curl -sfL --max-time 10 "$url" 2>/dev/null)
+        if [ $? -eq 0 ] && [ -n "$result" ]; then
             echo "$result"
             return 0
-        }
+        fi
     else
         return 1
     fi

--- a/installer/utils.sh
+++ b/installer/utils.sh
@@ -219,16 +219,19 @@ fetch_stdout() {
     url="$1"
 
     # Try direct GitHub download first
+    result=""
     if command_exists wget; then
-        result=$(wget -qO- --timeout=10 "$url" 2>/dev/null) && [ -n "$result" ] && {
+        result=$(wget -qO- --timeout=10 "$url" 2>/dev/null)
+        if [ $? -eq 0 ] && [ -n "$result" ]; then
             echo "$result"
             return 0
-        }
+        fi
     elif command_exists curl; then
-        result=$(curl -sfL --max-time 10 "$url" 2>/dev/null) && [ -n "$result" ] && {
+        result=$(curl -sfL --max-time 10 "$url" 2>/dev/null)
+        if [ $? -eq 0 ] && [ -n "$result" ]; then
             echo "$result"
             return 0
-        }
+        fi
     else
         return 1
     fi


### PR DESCRIPTION
This pull request refactors the `fetch_stdout()` function in both `install.sh` and `installer/utils.sh` to simplify the logic for handling direct downloads using `wget` and `curl`. The changes improve readability and ensure that results are only returned if the download is successful and non-empty.

Improvements to direct download logic:

* Simplified the conditional flow so that results from `wget` or `curl` are only echoed and returned if they are non-empty, reducing unnecessary variable assignments and checks in both `install.sh` and `installer/utils.sh`. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL286-R297) [[2]](diffhunk://#diff-170f986a2a0dd168c89e3feabb961ff41dfae2cf1070857d65047f97e75c290cL222-R233)

Error handling and code clarity:

* Moved the fallback logic to only run if both `wget` and `curl` fail or return empty results, making the function's behavior clearer and more robust. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL286-R297) [[2]](diffhunk://#diff-170f986a2a0dd168c89e3feabb961ff41dfae2cf1070857d65047f97e75c290cL222-R233)