### PR TITLE
feat(tcp): add TCP Timestamp faking strategy and related configurations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,10 @@
 # B4 - Bye Bye Big Bro
 
-## [1.33.1] - 2026-01-26
+## [1.33.2] - 2026-02-07
 
+- ADDED: `TCP Timestamp` faking strategy - a new way to make fake packets look wrong to the real server (so it ignores them) while still fooling DPI. Instead of using a low TTL or wrong sequence number, B4 sends fake packets with an outdated timestamp. Inspired by the [youtubeUnblock](https://github.com/Waujito/youtubeUnblock) project. Select `TCP Timestamp` in the Faking strategy dropdown to use it.
 - FIXED: UDP/QUIC traffic stopping to match after some time. B4 now keeps server-to-domain associations active as long as traffic is flowing, preventing the "works at first, then stops" issue.
-- IMPROVED: Rewrite TLS ClientHello payload generation.
+- IMPROVED: Rewrite TLS `ClientHello` payload generation.
 
 ## [1.32.0] - 2026-01-19
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -103,17 +103,18 @@ var DefaultSetConfig = SetConfig{
 	},
 
 	Faking: FakingConfig{
-		SNI:           true,
-		TTL:           7,
-		SNISeqLength:  1,
-		SNIType:       FakePayloadDefault1,
-		CustomPayload: "",
-		Strategy:      "pastseq",
-		SeqOffset:     10000,
-		PayloadFile:   "",
-		PayloadData:   []byte{},
-		TLSMod:        []string{},
-		TCPMD5:        false,
+		SNI:               true,
+		TTL:               7,
+		SNISeqLength:      1,
+		SNIType:           FakePayloadDefault1,
+		CustomPayload:     "",
+		Strategy:          "pastseq",
+		SeqOffset:         10000,
+		PayloadFile:       "",
+		PayloadData:       []byte{},
+		TLSMod:            []string{},
+		TimestampDecrease: 600000, // Default value for timestamp faking strategy
+		TCPMD5:            false,
 
 		SNIMutation: SNIMutationConfig{
 			Mode:         ConfigOff, // "off", "random", "grease", "padding", "fakeext", "fakesni", "advanced"

--- a/src/config/migration.go
+++ b/src/config/migration.go
@@ -32,6 +32,15 @@ var migrationRegistry = map[int]MigrationFunc{
 	13: migrateV13to14,
 	14: migrateV14to15, // Flatten TCP desync settings into nested struct
 	15: migrateV15to16, // Add TCP Incoming config
+	16: migrateV16to17,
+}
+
+func migrateV16to17(c *Config, _ map[string]interface{}) error {
+
+	for _, set := range c.Sets {
+		set.Faking.TimestampDecrease = DefaultSetConfig.Faking.TimestampDecrease
+	}
+	return nil
 }
 
 func migrateV15to16(c *Config, _ map[string]interface{}) error {

--- a/src/config/types.go
+++ b/src/config/types.go
@@ -101,16 +101,17 @@ type FragmentationConfig struct {
 }
 
 type FakingConfig struct {
-	SNI           bool     `json:"sni" bson:"sni"`
-	TTL           uint8    `json:"ttl" bson:"ttl"`
-	Strategy      string   `json:"strategy" bson:"strategy"`
-	SeqOffset     int32    `json:"seq_offset" bson:"seq_offset"`
-	SNISeqLength  int      `json:"sni_seq_length" bson:"sni_seq_length"`
-	SNIType       int      `json:"sni_type" bson:"sni_type"`
-	CustomPayload string   `json:"custom_payload" bson:"custom_payload"`
-	PayloadFile   string   `json:"payload_file" bson:"payload_file"`
-	PayloadData   []byte   `json:"-" bson:"-"`
-	TLSMod        []string `json:"tls_mod" bson:"tls_mod"` // e.g. ["rnd", "dupsid"]
+	SNI               bool     `json:"sni" bson:"sni"`
+	TTL               uint8    `json:"ttl" bson:"ttl"`
+	Strategy          string   `json:"strategy" bson:"strategy"`
+	SeqOffset         int32    `json:"seq_offset" bson:"seq_offset"`
+	SNISeqLength      int      `json:"sni_seq_length" bson:"sni_seq_length"`
+	SNIType           int      `json:"sni_type" bson:"sni_type"`
+	CustomPayload     string   `json:"custom_payload" bson:"custom_payload"`
+	PayloadFile       string   `json:"payload_file" bson:"payload_file"`
+	PayloadData       []byte   `json:"-" bson:"-"`
+	TLSMod            []string `json:"tls_mod" bson:"tls_mod"`                       // e.g. ["rnd", "dupsid"]
+	TimestampDecrease uint32   `json:"timestamp_decrease" bson:"timestamp_decrease"` // Amount to decrease TCP timestamp option
 
 	SNIMutation SNIMutationConfig `json:"sni_mutation" bson:"sni_mutation"`
 	TCPMD5      bool              `json:"tcp_md5" bson:"tcp_md5"` // Enable TCP MD5 option insertion

--- a/src/discovery/preset.go
+++ b/src/discovery/preset.go
@@ -1414,21 +1414,26 @@ func GetPhase2Presets(family StrategyFamily) []ConfigPreset {
 		}
 
 		// Strategy variations
-		strategies := []string{"ttl", "pastseq", "randseq", "tcp_check", "md5sum"}
+		strategies := []string{"ttl", "pastseq", "randseq", "tcp_check", "md5sum", "timestamp"}
 		for i, strat := range strategies {
+			cfg := config.FakingConfig{
+				SNI:          true,
+				TTL:          7,
+				Strategy:     strat,
+				SeqOffset:    10000,
+				SNISeqLength: 1,
+				SNIType:      config.FakePayloadDefault1,
+			}
+			// Set default timestamp decrease for timestamp strategy
+			if strat == "timestamp" {
+				cfg.TimestampDecrease = 600000
+			}
 			presets = append(presets, ConfigPreset{
 				Name:     formatName("fake-%s", strat),
 				Family:   FamilyFakeSNI,
 				Phase:    PhaseOptimize,
 				Priority: i + 20,
-				Config: withFaking(base, config.FakingConfig{
-					SNI:          true,
-					TTL:          7,
-					Strategy:     strat,
-					SeqOffset:    10000,
-					SNISeqLength: 1,
-					SNIType:      config.FakePayloadDefault1,
-				}),
+				Config:   withFaking(base, cfg),
 			})
 		}
 

--- a/src/http/ui/src/components/sets/Faking.tsx
+++ b/src/http/ui/src/components/sets/Faking.tsx
@@ -21,7 +21,7 @@ interface FakingSettingsProps {
   config: B4SetConfig;
   onChange: (
     field: string,
-    value: string | boolean | number | string[]
+    value: string | boolean | number | string[],
   ) => void;
 }
 
@@ -31,6 +31,7 @@ const FAKE_STRATEGIES = [
   { value: "pastseq", label: "Past Sequence" },
   { value: "tcp_check", label: "TCP Check" },
   { value: "md5sum", label: "MD5 Sum" },
+  { value: "timestamp", label: "TCP Timestamp" },
 ];
 
 const FAKE_PAYLOAD_TYPES = [
@@ -100,7 +101,7 @@ export const FakingSettings = ({ config, onChange }: FakingSettingsProps) => {
     const current = mutation.fake_snis || [];
     onChange(
       "faking.sni_mutation.fake_snis",
-      current.filter((s) => s !== sni)
+      current.filter((s) => s !== sni),
     );
   };
 
@@ -226,6 +227,20 @@ export const FakingSettings = ({ config, onChange }: FakingSettingsProps) => {
               disabled={!config.faking.sni}
             />
           </Grid>
+          {config.faking.strategy === "timestamp" && (
+            <Grid size={{ xs: 12, md: 4 }}>
+              <B4TextField
+                label="Timestamp Decrease"
+                type="number"
+                value={config.faking.timestamp_decrease || 600000}
+                onChange={(e) =>
+                  onChange("faking.timestamp_decrease", Number(e.target.value))
+                }
+                helperText="Amount to decrease TCP timestamp option (default: 600000)"
+                disabled={!config.faking.sni}
+              />
+            </Grid>
+          )}
           <Grid size={{ xs: 12, md: 4 }}>
             <B4Slider
               label="Fake Packet Count"
@@ -251,7 +266,7 @@ export const FakingSettings = ({ config, onChange }: FakingSettingsProps) => {
                 color="text.secondary"
                 sx={{ display: "block", mb: 1 }}
               >
-                Modify fake TLS ClientHello to improve bypass (zapret-style)
+                Modify fake TLS ClientHello to improve bypass
               </Typography>
               <Stack direction="row" spacing={2}>
                 <B4Switch

--- a/src/http/ui/src/models/config.ts
+++ b/src/http/ui/src/models/config.ts
@@ -3,7 +3,8 @@ export type FakingStrategy =
   | "pastseq"
   | "randseq"
   | "tcp_check"
-  | "md5sum";
+  | "md5sum"
+  | "timestamp";
 
 export enum FakingPayloadType {
   RANDOM = 0,
@@ -41,6 +42,7 @@ export interface FakingConfig {
   payload_file: string;
   tls_mod: string[];
   tcp_md5: boolean;
+  timestamp_decrease: number;
 }
 export type FragmentationStrategy =
   | "tcp"

--- a/src/nfq/syn.go
+++ b/src/nfq/syn.go
@@ -62,6 +62,13 @@ func (w *Worker) sendFakeSyn(set *config.SetConfig, raw []byte, ipHdrLen, tcpHdr
 			seq -= offset
 		}
 		binary.BigEndian.PutUint32(fakePkt[ipHdrLen+4:ipHdrLen+8], seq)
+
+	case "timestamp":
+		decrease := set.Faking.TimestampDecrease
+		if decrease == 0 {
+			decrease = 600000 // Default value matching youtubeUnblock
+		}
+		sock.DecreaseTCPTimestamp(fakePkt, decrease, false)
 	}
 
 	sock.FixIPv4Checksum(fakePkt[:ipHdrLen])
@@ -131,6 +138,13 @@ func (w *Worker) sendFakeSynV6(set *config.SetConfig, raw []byte, ipHdrLen, tcpH
 			seq -= offset
 		}
 		binary.BigEndian.PutUint32(fakePkt[ipHdrLen+4:ipHdrLen+8], seq)
+
+	case "timestamp":
+		decrease := set.Faking.TimestampDecrease
+		if decrease == 0 {
+			decrease = 600000 // Default value matching youtubeUnblock
+		}
+		sock.DecreaseTCPTimestamp(fakePkt, decrease, true)
 	}
 
 	sock.FixTCPChecksumV6(fakePkt)

--- a/src/sock/fake_ipv4.go
+++ b/src/sock/fake_ipv4.go
@@ -61,6 +61,12 @@ func BuildFakeSNIPacketV4(original []byte, cfg *config.SetConfig) []byte {
 			off := uint32(cfg.Faking.SeqOffset) + uint32(dlen)
 			binary.BigEndian.PutUint32(fake[ipHdrLen+4:ipHdrLen+8], seq-off)
 		}
+	case "timestamp":
+		decrease := cfg.Faking.TimestampDecrease
+		if decrease == 0 {
+			decrease = 600000 // Default value matching youtubeUnblock
+		}
+		DecreaseTCPTimestamp(fake, decrease, false)
 	case "tcp_check":
 	default:
 	}

--- a/src/sock/fake_ipv6.go
+++ b/src/sock/fake_ipv6.go
@@ -65,6 +65,12 @@ func BuildFakeSNIPacketV6(original []byte, cfg *config.SetConfig) []byte {
 			off := uint32(cfg.Faking.SeqOffset) + uint32(dlen)
 			binary.BigEndian.PutUint32(fake[ipv6HdrLen+4:ipv6HdrLen+8], seq-off)
 		}
+	case "timestamp":
+		decrease := cfg.Faking.TimestampDecrease
+		if decrease == 0 {
+			decrease = 600000 // Default value matching youtubeUnblock
+		}
+		DecreaseTCPTimestamp(fake, decrease, true)
 	case "tcp_check":
 	default:
 	}

--- a/src/sock/tcp_md5.go
+++ b/src/sock/tcp_md5.go
@@ -21,14 +21,14 @@ func AddTCPMD5Option(packet []byte, isIPv6 bool) []byte {
 	payloadStart := ipHdrLen + tcpHdrLen
 
 	md5Opt := make([]byte, 20)
-	md5Opt[0] = 1           // NOP
-	md5Opt[1] = 1           // NOP
-	md5Opt[2] = 19          // MD5 kind
-	md5Opt[3] = 18          // MD5 length
-	rand.Read(md5Opt[4:20]) // 16 bytes fake MD5
+	md5Opt[0] = 1
+	md5Opt[1] = 1
+	md5Opt[2] = 19
+	md5Opt[3] = 18
+	rand.Read(md5Opt[4:20])
 
 	newTCPHdrLen := tcpHdrLen + 20
-	if newTCPHdrLen > 60 { // Max TCP header is 60 bytes
+	if newTCPHdrLen > 60 {
 		return packet
 	}
 

--- a/src/sock/tcp_timestamp.go
+++ b/src/sock/tcp_timestamp.go
@@ -1,0 +1,69 @@
+package sock
+
+import "encoding/binary"
+
+const (
+	TCPOptionNOP       = 1
+	TCPOptionTimestamp = 8
+	TCPTimestampLength = 10
+)
+
+func DecreaseTCPTimestamp(packet []byte, decrease uint32, isIPv6 bool) bool {
+	var ipHdrLen int
+	if isIPv6 {
+		ipHdrLen = 40
+	} else {
+		ipHdrLen = int((packet[0] & 0x0F) * 4)
+	}
+
+	if len(packet) < ipHdrLen+20 {
+		return false
+	}
+
+	tcpHdrLen := int((packet[ipHdrLen+12] >> 4) * 4)
+	if tcpHdrLen < 20 || len(packet) < ipHdrLen+tcpHdrLen {
+		return false
+	}
+
+	optionsStart := ipHdrLen + 20
+	optionsEnd := ipHdrLen + tcpHdrLen
+
+	i := optionsStart
+	for i < optionsEnd {
+		kind := packet[i]
+
+		if kind == 0 {
+			break
+		}
+
+		if kind == TCPOptionNOP {
+			i++
+			continue
+		}
+
+		if i+1 >= optionsEnd {
+			break
+		}
+
+		length := int(packet[i+1])
+		if length < 2 || i+length > optionsEnd {
+			break
+		}
+
+		if kind == TCPOptionTimestamp && length == TCPTimestampLength {
+			if i+10 <= optionsEnd {
+				tsvalOffset := i + 2
+				tsval := binary.BigEndian.Uint32(packet[tsvalOffset : tsvalOffset+4])
+
+				newTSval := tsval - decrease
+				binary.BigEndian.PutUint32(packet[tsvalOffset:tsvalOffset+4], newTSval)
+
+				return true
+			}
+		}
+
+		i += length
+	}
+
+	return false
+}

--- a/src/sock/tcp_timestamp_test.go
+++ b/src/sock/tcp_timestamp_test.go
@@ -1,0 +1,131 @@
+package sock
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// buildTestTCPPacketWithTimestamp creates a test TCP packet with a timestamp option
+func buildTestTCPPacketWithTimestamp(isIPv6 bool, tsval uint32) []byte {
+	var packet []byte
+	var ipHdrLen int
+
+	if isIPv6 {
+		ipHdrLen = 40
+		// Minimal IPv6 header
+		packet = make([]byte, ipHdrLen+32) // 40 IP + 32 TCP (20 base + 12 options with NOPs)
+		packet[0] = 0x60 // Version 6
+		binary.BigEndian.PutUint16(packet[4:6], 32) // Payload length
+		packet[6] = 6 // Next header: TCP
+		packet[7] = 64 // Hop limit
+	} else {
+		ipHdrLen = 20
+		// Minimal IPv4 header
+		packet = make([]byte, ipHdrLen+32) // 20 IP + 32 TCP (20 base + 12 options with NOPs)
+		packet[0] = 0x45 // Version 4, IHL 5
+		binary.BigEndian.PutUint16(packet[2:4], uint16(len(packet))) // Total length
+		packet[9] = 6 // Protocol: TCP
+	}
+
+	// TCP header starts after IP header
+	tcpStart := ipHdrLen
+
+	// Set TCP data offset to 8 (32 bytes header)
+	packet[tcpStart+12] = 0x80 // Data offset = 8 (8 * 4 = 32 bytes)
+
+	// Add TCP timestamp option
+	// Format: NOP (1) | NOP (1) | Kind=8 (1) | Len=10 (1) | TSval (4) | TSecr (4)
+	optStart := tcpStart + 20
+	packet[optStart] = TCPOptionNOP        // NOP
+	packet[optStart+1] = TCPOptionNOP      // NOP
+	packet[optStart+2] = TCPOptionTimestamp // Kind = 8
+	packet[optStart+3] = TCPTimestampLength // Length = 10
+	binary.BigEndian.PutUint32(packet[optStart+4:optStart+8], tsval) // TSval
+	binary.BigEndian.PutUint32(packet[optStart+8:optStart+12], 0)    // TSecr
+
+	return packet
+}
+
+func TestDecreaseTCPTimestamp_IPv4(t *testing.T) {
+	originalTSval := uint32(1000000)
+	decrease := uint32(600000)
+	expected := originalTSval - decrease
+
+	packet := buildTestTCPPacketWithTimestamp(false, originalTSval)
+
+	result := DecreaseTCPTimestamp(packet, decrease, false)
+	if !result {
+		t.Fatal("DecreaseTCPTimestamp returned false, expected true")
+	}
+
+	// Verify the timestamp was decreased
+	ipHdrLen := 20
+	tcpStart := ipHdrLen
+	optStart := tcpStart + 20
+	newTSval := binary.BigEndian.Uint32(packet[optStart+4 : optStart+8])
+
+	if newTSval != expected {
+		t.Errorf("TSval not decreased correctly. Expected %d, got %d", expected, newTSval)
+	}
+}
+
+func TestDecreaseTCPTimestamp_IPv6(t *testing.T) {
+	originalTSval := uint32(2000000)
+	decrease := uint32(600000)
+	expected := originalTSval - decrease
+
+	packet := buildTestTCPPacketWithTimestamp(true, originalTSval)
+
+	result := DecreaseTCPTimestamp(packet, decrease, true)
+	if !result {
+		t.Fatal("DecreaseTCPTimestamp returned false, expected true")
+	}
+
+	// Verify the timestamp was decreased
+	ipHdrLen := 40
+	tcpStart := ipHdrLen
+	optStart := tcpStart + 20
+	newTSval := binary.BigEndian.Uint32(packet[optStart+4 : optStart+8])
+
+	if newTSval != expected {
+		t.Errorf("TSval not decreased correctly. Expected %d, got %d", expected, newTSval)
+	}
+}
+
+func TestDecreaseTCPTimestamp_NoTimestamp(t *testing.T) {
+	// Create a packet without timestamp option
+	packet := make([]byte, 40) // 20 IP + 20 TCP (no options)
+	packet[0] = 0x45           // Version 4, IHL 5
+	packet[9] = 6              // Protocol: TCP
+	packet[20+12] = 0x50       // Data offset = 5 (20 bytes, no options)
+
+	result := DecreaseTCPTimestamp(packet, 600000, false)
+	if result {
+		t.Error("DecreaseTCPTimestamp should return false for packet without timestamp")
+	}
+}
+
+func TestDecreaseTCPTimestamp_Underflow(t *testing.T) {
+	// Test with TSval smaller than decrease amount (should underflow)
+	originalTSval := uint32(100000)
+	decrease := uint32(600000)
+
+	packet := buildTestTCPPacketWithTimestamp(false, originalTSval)
+
+	result := DecreaseTCPTimestamp(packet, decrease, false)
+	if !result {
+		t.Fatal("DecreaseTCPTimestamp returned false, expected true")
+	}
+
+	// Verify underflow behavior (wraps around)
+	ipHdrLen := 20
+	tcpStart := ipHdrLen
+	optStart := tcpStart + 20
+	newTSval := binary.BigEndian.Uint32(packet[optStart+4 : optStart+8])
+
+	// With uint32, this should wrap around
+	expected := originalTSval - decrease // Will wrap around due to uint32
+	if newTSval != expected {
+		t.Errorf("TSval underflow not handled correctly. Expected %d, got %d", expected, newTSval)
+	}
+}


### PR DESCRIPTION
- Introduced a new faking strategy using outdated TCP timestamps to evade detection.
- Updated configuration to include TimestampDecrease parameter.
- Enhanced migration logic to support new timestamp settings.
- Modified UI components to allow selection of the new timestamp strategy.
- Implemented packet manipulation functions to decrease TCP timestamps.
- Added tests for timestamp functionality to ensure correct behavior.