### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -781,7 +781,7 @@ detect_architecture() {
         ;;
     mips64)
         # Check MIPS endianness
-        if grep -qi "mips.*el\|el.*mips" /proc/cpuinfo 2>/dev/null || uname -m | grep -qi "el"; then
+        if uname -m | grep -qi "el"; then
             arch_variant="mips64le"
         else
             arch_variant="mips64"

--- a/installer/system.sh
+++ b/installer/system.sh
@@ -193,7 +193,7 @@ detect_architecture() {
         ;;
     mips64)
         # Check MIPS endianness
-        if grep -qi "mips.*el\|el.*mips" /proc/cpuinfo 2>/dev/null || uname -m | grep -qi "el"; then
+        if uname -m | grep -qi "el"; then
             arch_variant="mips64le"
         else
             arch_variant="mips64"
@@ -208,7 +208,7 @@ detect_architecture() {
         ;;
     mips*)
         # 32-bit MIPS - determine endianness
-        if grep -qi "mips.*el\|el.*mips" /proc/cpuinfo 2>/dev/null || uname -m | grep -qi "el"; then
+        if uname -m | grep -qi "el"; then
             arch_variant="mipsle"
         else
             arch_variant="mips"


### PR DESCRIPTION
**Fix incorrect MIPS endianness detection (false positive on 'implemented')**
What changes:
This PR fixes a bug where Big Endian MIPS architectures (mips) were incorrectly detected as Little Endian (mipsle).

The issue:
The previous logic checked /proc/cpuinfo using the regex grep "mips.*el\|el.*mips". This caused a false positive on devices where cpuinfo contains lines like:

ASEs implemented        : mips16 dsp dsp2
The regex matched "mips" in mips16 and "el" in implemented, incorrectly setting the architecture to mipsle on a standard mips system (e.g., TP-Link Archer C7, QCA956X).

The fix:
I updated the script to rely on uname -m for determining endianness (mips vs mipsel), which is standard and reliable across Linux systems/OpenWrt. The cpuinfo parsing is now restricted only to checking for FPU presence (softfloat).