### PR TITLE
fix mikrotik-container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ COPY --from=go-builder /b4 /usr/local/bin/b4
 VOLUME /etc/b4
 EXPOSE 7000
 
-ENTRYPOINT ["b4", "--config", "/etc/b4/config.json"]
+ENTRYPOINT ["b4"]

--- a/src/http/handler/system.go
+++ b/src/http/handler/system.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"syscall"
 	"time"
 
@@ -21,70 +20,35 @@ func (api *API) RegisterSystemApi() {
 	api.mux.HandleFunc("/api/system/cache", api.handleCacheStats)
 }
 
-// detectServiceManager determines which service manager is managing B4
 func detectServiceManager() string {
-	// Check for systemd
 	if _, err := os.Stat("/etc/systemd/system/b4.service"); err == nil {
 		if _, err := exec.LookPath("systemctl"); err == nil {
 			return "systemd"
 		}
 	}
 
-	// Check for Entware/OpenWRT init script
 	if _, err := os.Stat("/opt/etc/init.d/S99b4"); err == nil {
 		return "entware"
 	}
 
-	// Check for standard init script
 	if _, err := os.Stat("/etc/init.d/b4"); err == nil {
 		return "init"
 	}
 
-	// Check if running inside Docker
 	if isDockerEnvironment() {
 		return "docker"
 	}
 
-	// Check if running as a standalone process (no service manager)
 	return "standalone"
 }
 
-// isDockerEnvironment checks if the process is running inside a container
-// Supports Docker, MikroTik containers, and other container runtimes
 func isDockerEnvironment() bool {
-	// Check for /.dockerenv file (standard Docker)
 	if _, err := os.Stat("/.dockerenv"); err == nil {
 		return true
 	}
-
-	// Check for /.dockerinit file (some Docker variants)
-	if _, err := os.Stat("/.dockerinit"); err == nil {
-		return true
-	}
-
-	// Check for container environment variable (used by many container runtimes)
 	if os.Getenv("container") != "" {
 		return true
 	}
-
-	// Check for Docker-specific environment variables
-	if os.Getenv("DOCKER_CONTAINER") == "true" {
-		return true
-	}
-
-	// Check cgroup for container detection
-	if data, err := os.ReadFile("/proc/1/cgroup"); err == nil {
-		content := string(data)
-		// Check for various container runtime signatures
-		if strings.Contains(content, "docker") ||
-			strings.Contains(content, "lxc") ||
-			strings.Contains(content, "containerd") ||
-			strings.Contains(content, "kubepods") ||
-			strings.Contains(content, "microk8s") {
-			return true
-		}
-	}
-
 	return false
 }
 
@@ -155,17 +119,13 @@ func (api *API) handleRestart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Send response immediately before triggering restart
 	setJsonHeader(w)
 	json.NewEncoder(w).Encode(response)
 
-	// Flush the response to ensure it's sent
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()
 	}
 
-	// Trigger restart in a goroutine with a small delay
-	// This allows the HTTP response to be sent before the service stops
 	go func() {
 		time.Sleep(500 * time.Millisecond)
 		log.Infof("Executing restart command: %s", response.RestartCommand)
@@ -284,7 +244,6 @@ func (api *API) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		log.Infof("Installer downloaded, starting update process...")
 		log.Infof("Service will stop now - this is expected")
 
-		// Use systemd-run to execute in separate scope for systemd systems
 		var cmd *exec.Cmd
 		if serviceManager == "systemd" {
 			args := []string{"--scope", "--unit=b4-update", installerPath, "--update", "--quiet"}
@@ -293,7 +252,6 @@ func (api *API) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			}
 			cmd = exec.Command("systemd-run", args...)
 		} else {
-			// For non-systemd, use nohup
 			args := []string{installerPath, "--update", "--quiet"}
 			if req.Version != "" {
 				args = append(args, req.Version)


### PR DESCRIPTION
версия 3.18 успешно устанавливается на микротик, страница настроек отображается, но в сетевых интерфейсах не отображается интерфейс, не сохраняются данные, внесенные после настроек. Подобный баг был подтвержден в чате. 
с помощью ллмок внесены изменения, после них создан образ и запущен на микротике - интерфейс отображается, данные сохраняются. просьба рассмотреть для внесения изменений в будущие версии. 

## Изменения для Pull Request

### Описание изменений:

__1. Улучшено определение контейнерной среды выполнения__ (`src/http/handler/system.go`)

Расширена функция `isDockerEnvironment()` для более надёжного определения различных контейнерных окружений:

- Добавлена проверка файла `/.dockerinit` (для некоторых вариантов Docker)
- Добавлена проверка переменной окружения `container` (используется в различных container runtimes)
- Добавлена проверка переменной окружения `DOCKER_CONTAINER`
- Добавлена проверка `/proc/1/cgroup` для определения контейнерных сред (docker, lxc, containerd, kubepods, microk8s)

```go
func isDockerEnvironment() bool {
    // Check for /.dockerenv file (standard Docker)
    if _, err := os.Stat("/.dockerenv"); err == nil {
        return true
    }

    // Check for /.dockerinit file (some Docker variants)
    if _, err := os.Stat("/.dockerinit"); err == nil {
        return true
    }

    // Check for container environment variable
    if os.Getenv("container") != "" {
        return true
    }

    // Check for Docker-specific environment variables
    if os.Getenv("DOCKER_CONTAINER") == "true" {
        return true
    }

    // Check cgroup for container detection
    if data, err := os.ReadFile("/proc/1/cgroup"); err == nil {
        content := string(data)
        if strings.Contains(content, "docker") ||
            strings.Contains(content, "lxc") ||
            strings.Contains(content, "containerd") ||
            strings.Contains(content, "kubepods") ||
            strings.Contains(content, "microk8s") {
            return true
        }
    }

    return false
}
```
