### PR TITLE
Fix domain routing learning for local DNS replies

### DIFF
--- a/src/tables/iptables.go
+++ b/src/tables/iptables.go
@@ -452,6 +452,7 @@ func (manager *IPTablesManager) buildManifest() (Manifest, error) {
 
 		rules = append(rules,
 			Rule{manager: manager, IPT: ipt, Table: "mangle", Chain: "PREROUTING", Action: "I", Spec: dnsResponseSpec},
+			Rule{manager: manager, IPT: ipt, Table: "mangle", Chain: "OUTPUT", Action: "I", Spec: dnsResponseSpec},
 			Rule{manager: manager, IPT: ipt, Table: "mangle", Chain: "OUTPUT", Action: "I",
 				Spec: []string{"-m", "mark", "--mark", markAccept, "-j", "ACCEPT"}},
 			Rule{manager: manager, IPT: ipt, Table: "mangle", Chain: "OUTPUT", Action: "A",

--- a/src/tables/nftables.go
+++ b/src/tables/nftables.go
@@ -262,6 +262,9 @@ func (n *NFTablesManager) Apply() error {
 	if err := n.addQueueRule("prerouting", "udp", "sport", "53", "counter"); err != nil {
 		return err
 	}
+	if err := n.addQueueRule("output", "udp", "sport", "53", "counter"); err != nil {
+		return err
+	}
 
 	if err := n.addQueueRule("prerouting", "tcp", "sport", tcpPortExpr, "ct", "original", "packets", "<", tcpLimit, "counter"); err != nil {
 		return err


### PR DESCRIPTION
This PR fixes domain-based routing population when DNS replies are generated locally on the router (for example, via dnsmasq on OpenWrt). udp sport 53 responses are now enqueued from OUTPUT in addition to PREROUTING, so b4 can reliably learn resolved IPs and add them to b4_route sets in local-resolver setups.