### PR TITLE
Fix routing for Ethernet/VLAN egress by using gateway-aware policy routes

### DIFF
--- a/src/tables/routing.go
+++ b/src/tables/routing.go
@@ -465,6 +465,7 @@ func routeDefaultGatewayForIface(iface string, ipv6 bool) string {
 	args = append(args, "route", "show", "default", "dev", iface)
 	out, err := run(args...)
 	if err != nil {
+		log.Tracef("Routing: gateway lookup failed for %s: %v", iface, err)
 		return ""
 	}
 	for _, line := range strings.Split(out, "\n") {


### PR DESCRIPTION
This PR fixes policy routing for egress interfaces that require a next-hop gateway (for example Ethernet/VLAN like eth1.22). requests to public IPs and broken routing on non-point-to-point links.
Now b4 first tries to resolve a default gateway for the selected egress interface from main routing table and, when available, installs `default via <gateway> dev <iface>` in the policy table; otherwise it falls back to direct `default dev <iface>` for tun/wg/p2p-style interfaces.`