### PR TITLE
Fix nft routing set updates when batch contains duplicates

### DIFF
--- a/src/tables/routing_nft.go
+++ b/src/tables/routing_nft.go
@@ -71,7 +71,16 @@ func (b *routeNftBackend) addElements(setName string, ips []string, ttlSec int) 
 			}
 		}
 		args = append(args, "}")
-		runLogged(fmt.Sprintf("routing: add %d element(s) to %s", len(chunk), setName), args...)
+		if _, err := run(args...); err != nil {
+			// nft can reject a whole batch on duplicate element; fall back to per-IP add.
+			for _, ip := range chunk {
+				single := []string{
+					"nft", "add", "element", "inet", routeNftTable, setName,
+					"{", ip, "timeout", ttl, "}",
+				}
+				runLogged("routing: add element "+ip+" to "+setName, single...)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes an issue in the nftables routing backend where batched `nft add element ... { ... }` updates could fail when a chunk contained already existing IPs.
When that happened, new IPs from the same chunk could be skipped silently.
Now b4 first tries batched insertion for performance, and if batch insertion fails, it falls back to per-element insertion for that chunk.
This preserves performance in the common case and guarantees that one duplicate does not block adding other new routing IPs.`