### PR TITLE
Refactor discovery runtime isolation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # B4 - Bye Bye Big Bro
 
+## [1.47.x] - 2026-0x-xx
+
+- IMPROVED: **Discovery no longer interrupts normal traffic** — discovery now runs on its own isolated flow, so your internet connection stays unaffected while discovery is testing strategies.
+- IMPROVED: **Stopping discovery is now reliable** — cancelling a running discovery now properly cleans up all firewall rules and stops immediately.
+
 ## [1.46.6] - 2026-03-26
 
 - FIXED: **B4 fails to start with large configs** — configs with many sets and hundreds of thousands of IPs caused an error on restart because all IPs were inlined into a single firewall command.

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -226,13 +226,11 @@ var DefaultConfig = Config{
 		},
 
 		Checker: DiscoveryConfig{
-			DiscoveryTimeoutSec:   5,
-			ConfigPropagateMs:     1500,
-			ReferenceDomain:       "yandex.ru",
-			ReferenceDNS:          []string{"9.9.9.9", "1.1.1.1", "8.8.8.8", "9.9.1.1", "8.8.4.4"},
-			ValidationTries:       1,
-			DiscoveryFlowMark:     (1 << 15) + 1,
-			DiscoveryInjectedMark: (1 << 15) + 2,
+			DiscoveryTimeoutSec: 5,
+			ConfigPropagateMs:   1500,
+			ReferenceDomain:     "yandex.ru",
+			ReferenceDNS:        []string{"9.9.9.9", "1.1.1.1", "8.8.8.8", "9.9.1.1", "8.8.4.4"},
+			ValidationTries:     1,
 		},
 		API: ApiConfig{
 			IPInfoToken: "",

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -89,16 +89,16 @@ var DefaultSetConfig = SetConfig{
 	},
 
 	Fragmentation: FragmentationConfig{
-		Strategy:          "tcp", // "tcp", "ip", "tls", "oob", "none", "combo", "hybrid", "disorder",  "extsplit", "firstbyte"
-		ReverseOrder:      true,
-		StrategyPool:      []string{},
-		MiddleSNI:         true,
-		SNIPosition:       1,
-		SNIPositionMax:    0,
-		OOBPosition:       0,
-		OOBPositionMax:    0,
-		OOBChar:           'x',
-		TLSRecordPosition: 0,
+		Strategy:             "tcp", // "tcp", "ip", "tls", "oob", "none", "combo", "hybrid", "disorder",  "extsplit", "firstbyte"
+		ReverseOrder:         true,
+		StrategyPool:         []string{},
+		MiddleSNI:            true,
+		SNIPosition:          1,
+		SNIPositionMax:       0,
+		OOBPosition:          0,
+		OOBPositionMax:       0,
+		OOBChar:              'x',
+		TLSRecordPosition:    0,
 		TLSRecordPositionMax: 0,
 
 		SeqOverlapBytes:   []byte{},
@@ -226,11 +226,13 @@ var DefaultConfig = Config{
 		},
 
 		Checker: DiscoveryConfig{
-			DiscoveryTimeoutSec: 5,
-			ConfigPropagateMs:   1500,
-			ReferenceDomain:     "yandex.ru",
-			ReferenceDNS:        []string{"9.9.9.9", "1.1.1.1", "8.8.8.8", "9.9.1.1", "8.8.4.4"},
-			ValidationTries:     1,
+			DiscoveryTimeoutSec:   5,
+			ConfigPropagateMs:     1500,
+			ReferenceDomain:       "yandex.ru",
+			ReferenceDNS:          []string{"9.9.9.9", "1.1.1.1", "8.8.8.8", "9.9.1.1", "8.8.4.4"},
+			ValidationTries:       1,
+			DiscoveryFlowMark:     (1 << 15) + 1,
+			DiscoveryInjectedMark: (1 << 15) + 2,
 		},
 		API: ApiConfig{
 			IPInfoToken: "",

--- a/src/config/methods.go
+++ b/src/config/methods.go
@@ -228,12 +228,20 @@ func (c *Config) Validate() error {
 	}
 
 	c.Queue.Mark = c.MainInjectedMark()
+
+	maxMark := uint(^uint32(0))
+	if c.Queue.Mark > maxMark {
+		return fmt.Errorf("mark value 0x%x exceeds uint32 max", c.Queue.Mark)
+	}
+	if c.Queue.Mark > maxMark-2 && c.System.Checker.DiscoveryFlowMark == 0 {
+		return fmt.Errorf("mark value 0x%x is too high for auto-derived discovery marks", c.Queue.Mark)
+	}
+
 	c.System.Checker.DiscoveryFlowMark = c.DiscoveryFlowMark()
 	c.System.Checker.DiscoveryInjectedMark = c.DiscoveryInjectedMark()
 
-	maxMark := uint64(^uint32(0))
-	if uint64(c.Queue.Mark) > maxMark || uint64(c.System.Checker.DiscoveryFlowMark) > maxMark || uint64(c.System.Checker.DiscoveryInjectedMark) > maxMark {
-		return fmt.Errorf("mark values must be <= %d", maxMark)
+	if c.System.Checker.DiscoveryFlowMark > maxMark || c.System.Checker.DiscoveryInjectedMark > maxMark {
+		return fmt.Errorf("discovery mark values exceed uint32 max")
 	}
 	if c.Queue.Mark == c.System.Checker.DiscoveryFlowMark ||
 		c.Queue.Mark == c.System.Checker.DiscoveryInjectedMark ||

--- a/src/config/methods.go
+++ b/src/config/methods.go
@@ -99,6 +99,27 @@ func (cfg *Config) ApplyLogLevel(level string) {
 	}
 }
 
+func (c *Config) MainInjectedMark() uint {
+	if c.Queue.Mark == 0 {
+		return DefaultConfig.Queue.Mark
+	}
+	return c.Queue.Mark
+}
+
+func (c *Config) DiscoveryFlowMark() uint {
+	if c.System.Checker.DiscoveryFlowMark != 0 {
+		return c.System.Checker.DiscoveryFlowMark
+	}
+	return c.MainInjectedMark() + 1
+}
+
+func (c *Config) DiscoveryInjectedMark() uint {
+	if c.System.Checker.DiscoveryInjectedMark != 0 {
+		return c.System.Checker.DiscoveryInjectedMark
+	}
+	return c.MainInjectedMark() + 2
+}
+
 func (c *Config) Validate() error {
 	c.System.WebServer.IsEnabled = c.System.WebServer.Port > 0 && c.System.WebServer.Port <= 65535
 
@@ -204,6 +225,20 @@ func (c *Config) Validate() error {
 
 	if c.Queue.StartNum < 0 || c.Queue.StartNum > 65535 {
 		return fmt.Errorf("queue-num must be between 0 and 65535")
+	}
+
+	c.Queue.Mark = c.MainInjectedMark()
+	c.System.Checker.DiscoveryFlowMark = c.DiscoveryFlowMark()
+	c.System.Checker.DiscoveryInjectedMark = c.DiscoveryInjectedMark()
+
+	maxMark := uint64(^uint32(0))
+	if uint64(c.Queue.Mark) > maxMark || uint64(c.System.Checker.DiscoveryFlowMark) > maxMark || uint64(c.System.Checker.DiscoveryInjectedMark) > maxMark {
+		return fmt.Errorf("mark values must be <= %d", maxMark)
+	}
+	if c.Queue.Mark == c.System.Checker.DiscoveryFlowMark ||
+		c.Queue.Mark == c.System.Checker.DiscoveryInjectedMark ||
+		c.System.Checker.DiscoveryFlowMark == c.System.Checker.DiscoveryInjectedMark {
+		return fmt.Errorf("queue marks must be unique: mark, discovery_flow_mark, discovery_injected_mark")
 	}
 
 	for _, set := range c.Sets {

--- a/src/config/methods_test.go
+++ b/src/config/methods_test.go
@@ -209,6 +209,73 @@ func TestValidate(t *testing.T) {
 	})
 }
 
+func TestValidateMarks(t *testing.T) {
+	t.Run("auto-derived discovery marks", func(t *testing.T) {
+		cfg := NewConfig()
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("default config should be valid: %v", err)
+		}
+		if cfg.System.Checker.DiscoveryFlowMark != cfg.Queue.Mark+1 {
+			t.Errorf("expected DiscoveryFlowMark=%d, got %d", cfg.Queue.Mark+1, cfg.System.Checker.DiscoveryFlowMark)
+		}
+		if cfg.System.Checker.DiscoveryInjectedMark != cfg.Queue.Mark+2 {
+			t.Errorf("expected DiscoveryInjectedMark=%d, got %d", cfg.Queue.Mark+2, cfg.System.Checker.DiscoveryInjectedMark)
+		}
+	})
+
+	t.Run("explicit discovery marks preserved", func(t *testing.T) {
+		cfg := NewConfig()
+		cfg.System.Checker.DiscoveryFlowMark = 0xAAAA
+		cfg.System.Checker.DiscoveryInjectedMark = 0xBBBB
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.System.Checker.DiscoveryFlowMark != 0xAAAA {
+			t.Errorf("expected DiscoveryFlowMark=0xAAAA, got 0x%x", cfg.System.Checker.DiscoveryFlowMark)
+		}
+		if cfg.System.Checker.DiscoveryInjectedMark != 0xBBBB {
+			t.Errorf("expected DiscoveryInjectedMark=0xBBBB, got 0x%x", cfg.System.Checker.DiscoveryInjectedMark)
+		}
+	})
+
+	t.Run("mark collision rejected", func(t *testing.T) {
+		cfg := NewConfig()
+		cfg.Queue.Mark = 100
+		cfg.System.Checker.DiscoveryFlowMark = 100
+		cfg.System.Checker.DiscoveryInjectedMark = 200
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error when queue mark equals discovery flow mark")
+		}
+	})
+
+	t.Run("discovery marks collision rejected", func(t *testing.T) {
+		cfg := NewConfig()
+		cfg.System.Checker.DiscoveryFlowMark = 500
+		cfg.System.Checker.DiscoveryInjectedMark = 500
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error when discovery marks are equal")
+		}
+	})
+
+	t.Run("mark too high for auto-derived discovery marks", func(t *testing.T) {
+		cfg := NewConfig()
+		cfg.Queue.Mark = uint(^uint32(0))
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error for mark at uint32 max with auto-derived discovery marks")
+		}
+	})
+
+	t.Run("mark at uint32 max with explicit discovery marks", func(t *testing.T) {
+		cfg := NewConfig()
+		cfg.Queue.Mark = uint(^uint32(0))
+		cfg.System.Checker.DiscoveryFlowMark = 1
+		cfg.System.Checker.DiscoveryInjectedMark = 2
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("expected valid config with explicit discovery marks at max mark: %v", err)
+		}
+	})
+}
+
 func TestAppendIP(t *testing.T) {
 	t.Run("appends new IPs", func(t *testing.T) {
 		targets := &TargetsConfig{}

--- a/src/config/migration.go
+++ b/src/config/migration.go
@@ -47,6 +47,14 @@ var migrationRegistry = map[int]MigrationFunc{
 	27: migrateV27to28, // Add per-set routing config
 	28: migrateV28to29, // Add position ranges and strategy pool
 	29: migrateV29to30, // Add MTProto proxy config
+	30: migrateV30to31, // Add discovery flow/injected marks
+}
+
+func migrateV30to31(c *Config, _ map[string]interface{}) error {
+	log.Tracef("Migration v30->v31: Adding discovery flow/injected marks")
+	c.System.Checker.DiscoveryFlowMark = DefaultConfig.System.Checker.DiscoveryFlowMark
+	c.System.Checker.DiscoveryInjectedMark = DefaultConfig.System.Checker.DiscoveryInjectedMark
+	return nil
 }
 
 func migrateV29to30(c *Config, _ map[string]interface{}) error {

--- a/src/config/migration.go
+++ b/src/config/migration.go
@@ -47,14 +47,6 @@ var migrationRegistry = map[int]MigrationFunc{
 	27: migrateV27to28, // Add per-set routing config
 	28: migrateV28to29, // Add position ranges and strategy pool
 	29: migrateV29to30, // Add MTProto proxy config
-	30: migrateV30to31, // Add discovery flow/injected marks
-}
-
-func migrateV30to31(c *Config, _ map[string]interface{}) error {
-	log.Tracef("Migration v30->v31: Adding discovery flow/injected marks")
-	c.System.Checker.DiscoveryFlowMark = DefaultConfig.System.Checker.DiscoveryFlowMark
-	c.System.Checker.DiscoveryInjectedMark = DefaultConfig.System.Checker.DiscoveryInjectedMark
-	return nil
 }
 
 func migrateV29to30(c *Config, _ map[string]interface{}) error {

--- a/src/config/types.go
+++ b/src/config/types.go
@@ -28,7 +28,7 @@ type ApiConfig struct {
 type QueueConfig struct {
 	StartNum          int            `json:"start_num"`
 	Threads           int            `json:"threads"`
-	Mark              uint           `json:"mark"`
+	Mark              uint           `json:"mark"` // Main injected packets mark
 	IPv4Enabled       bool           `json:"ipv4"`
 	IPv6Enabled       bool           `json:"ipv6"`
 	TCPConnBytesLimit int            `json:"tcp_conn_bytes_limit"`
@@ -36,6 +36,7 @@ type QueueConfig struct {
 	Interfaces        []string       `json:"interfaces"`
 	Devices           DevicesConfig  `json:"devices"`
 	MSSClamp          MSSClampConfig `json:"mss_clamp"`
+	IsDiscovery       bool           `json:"-"`
 }
 
 type DevicesConfig struct {
@@ -97,9 +98,9 @@ type UDPConfig struct {
 }
 
 type FragmentationConfig struct {
-	Strategy          string   `json:"strategy"` // Values: "tcp", "ip", "oob", "tls", "disorder",  "extsplit", "firstbyte", "combo", "none"
-	ReverseOrder      bool     `json:"reverse_order"`
-	StrategyPool      []string `json:"strategy_pool"`
+	Strategy     string   `json:"strategy"` // Values: "tcp", "ip", "oob", "tls", "disorder",  "extsplit", "firstbyte", "combo", "none"
+	ReverseOrder bool     `json:"reverse_order"`
+	StrategyPool []string `json:"strategy_pool"`
 
 	TLSRecordPosition    int `json:"tlsrec_pos"`     // where to split TLS record
 	TLSRecordPositionMax int `json:"tlsrec_pos_max"` // max for randomization (0 = use fixed)
@@ -168,12 +169,12 @@ type SystemConfig struct {
 }
 
 type MTProtoConfig struct {
-	Enabled     bool              `json:"enabled"`
-	Port        int               `json:"port"`
-	BindAddress string            `json:"bind_address"`
-	Secret      string            `json:"secret"`
-	FakeSNI     string            `json:"fake_sni"`
-	DCRelay     string            `json:"dc_relay"`
+	Enabled     bool   `json:"enabled"`
+	Port        int    `json:"port"`
+	BindAddress string `json:"bind_address"`
+	Secret      string `json:"secret"`
+	FakeSNI     string `json:"fake_sni"`
+	DCRelay     string `json:"dc_relay"`
 }
 
 type Socks5Config struct {
@@ -207,11 +208,13 @@ type WebServerConfig struct {
 }
 
 type DiscoveryConfig struct {
-	DiscoveryTimeoutSec int      `json:"discovery_timeout"`
-	ConfigPropagateMs   int      `json:"config_propagate_ms"`
-	ReferenceDomain     string   `json:"reference_domain"`
-	ReferenceDNS        []string `json:"reference_dns"`
-	ValidationTries     int      `json:"validation_tries"`
+	DiscoveryTimeoutSec   int      `json:"discovery_timeout"`
+	ConfigPropagateMs     int      `json:"config_propagate_ms"`
+	ReferenceDomain       string   `json:"reference_domain"`
+	ReferenceDNS          []string `json:"reference_dns"`
+	ValidationTries       int      `json:"validation_tries"`
+	DiscoveryFlowMark     uint     `json:"discovery_flow_mark"`
+	DiscoveryInjectedMark uint     `json:"discovery_injected_mark"`
 }
 
 type Logging struct {

--- a/src/discovery/discovery.go
+++ b/src/discovery/discovery.go
@@ -307,7 +307,6 @@ func (ds *DiscoverySuite) RunDiscovery() {
 		for _, preset := range cachedPresets {
 			select {
 			case <-ds.cancel:
-				ds.restoreConfig()
 				ds.finalize()
 				ds.logDiscoverySummary()
 				return
@@ -342,7 +341,6 @@ func (ds *DiscoverySuite) RunDiscovery() {
 			ds.CheckSuite.mu.Unlock()
 
 			log.DiscoveryLogf("Verified: no DPI bypass needed for any domain")
-			ds.restoreConfig()
 			ds.finalize()
 			ds.logDiscoverySummary()
 			return
@@ -357,7 +355,6 @@ func (ds *DiscoverySuite) RunDiscovery() {
 		// no packet manipulation strategy will help — the blocking is at IP level.
 		if ds.allDomainsTransportBlocked() {
 			log.Warnf("All domains have transport-level blocking (IP blocked) — extended search skipped")
-			ds.restoreConfig()
 			ds.finalize()
 			ds.logDiscoverySummary()
 			return
@@ -370,7 +367,6 @@ func (ds *DiscoverySuite) RunDiscovery() {
 
 		if len(workingFamilies) == 0 {
 			log.Warnf("No working bypass strategies found")
-			ds.restoreConfig()
 			ds.finalize()
 			ds.logDiscoverySummary()
 			return
@@ -391,7 +387,6 @@ func (ds *DiscoverySuite) RunDiscovery() {
 	}
 
 	ds.determineBest(baselineSpeed)
-	ds.restoreConfig()
 	ds.finalize()
 	ds.logDiscoverySummary()
 }
@@ -1747,13 +1742,6 @@ func (ds *DiscoverySuite) finalize() {
 		delete(activeSuites, ds.Id)
 		suitesMu.Unlock()
 	}()
-}
-
-func (ds *DiscoverySuite) restoreConfig() {
-	log.DiscoveryLogf("Restoring original configuration")
-	if err := ds.pool.UpdateConfig(ds.cfg); err != nil {
-		log.DiscoveryLogf("Failed to restore original configuration: %v", err)
-	}
 }
 
 func (ds *DiscoverySuite) logDiscoverySummary() {

--- a/src/discovery/discovery.go
+++ b/src/discovery/discovery.go
@@ -214,10 +214,6 @@ func (ds *DiscoverySuite) RunDiscovery() {
 	}
 	log.DiscoveryLogf("═══════════════════════════════════════")
 
-	suitesMu.Lock()
-	activeSuites[ds.Id] = ds.CheckSuite
-	suitesMu.Unlock()
-
 	defer func() {
 		log.SetDiscoveryActive(false)
 		ds.EndTime = time.Now()

--- a/src/discovery/discovery.go
+++ b/src/discovery/discovery.go
@@ -123,7 +123,7 @@ func humanizeError(raw string) string {
 	return raw
 }
 
-func NewDiscoverySuite(inputs []string, pool *nfq.Pool, skipDNS bool, skipCache bool, payloadFiles []string, validationTries int, tlsVersion string) *DiscoverySuite {
+func NewDiscoverySuite(inputs []string, pool *nfq.Pool, skipDNS bool, skipCache bool, payloadFiles []string, validationTries int, tlsVersion string, flowMark uint) *DiscoverySuite {
 	domainInputs := parseDiscoveryInputs(inputs)
 	if len(domainInputs) == 0 {
 		suite := NewCheckSuite(domainInputs)
@@ -160,6 +160,7 @@ func NewDiscoverySuite(inputs []string, pool *nfq.Pool, skipDNS bool, skipCache 
 		skipCache:       skipCache,
 		validationTries: validationTries,
 		tlsVersion:      tlsVersion,
+		flowMark:        flowMark,
 	}
 
 	if len(payloadFiles) > 0 {
@@ -221,6 +222,15 @@ func (ds *DiscoverySuite) RunDiscovery() {
 		log.SetDiscoveryActive(false)
 		ds.EndTime = time.Now()
 	}()
+
+	select {
+	case <-ds.cancel:
+		ds.setStatus(CheckStatusCanceled)
+		ds.finalize()
+		ds.logDiscoverySummary()
+		return
+	default:
+	}
 
 	ds.setStatus(CheckStatusRunning)
 
@@ -1172,6 +1182,8 @@ func (ds *DiscoverySuite) fetchUsingIPForDomain(di DomainInput, timeout time.Dur
 		IdleConnTimeout:       timeout,
 	}
 
+	baseDialer := markedDialer(ds.flowMark, timeout/2, timeout)
+
 	if ip != "" {
 		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			_, port, _ := net.SplitHostPort(addr)
@@ -1180,16 +1192,10 @@ func (ds *DiscoverySuite) fetchUsingIPForDomain(di DomainInput, timeout time.Dur
 			}
 			directAddr := net.JoinHostPort(ip, port)
 			log.Tracef("DNS bypass: connecting to %s instead of %s", directAddr, addr)
-			return (&net.Dialer{
-				Timeout:   timeout / 2,
-				KeepAlive: timeout,
-			}).DialContext(ctx, network, directAddr)
+			return baseDialer.DialContext(ctx, network, directAddr)
 		}
 	} else {
-		transport.DialContext = (&net.Dialer{
-			Timeout:   timeout / 2,
-			KeepAlive: timeout,
-		}).DialContext
+		transport.DialContext = baseDialer.DialContext
 	}
 
 	client := &http.Client{
@@ -1725,7 +1731,9 @@ func (ds *DiscoverySuite) setPhase(phase DiscoveryPhase) {
 func (ds *DiscoverySuite) finalize() {
 	ds.CheckSuite.mu.Lock()
 	ds.DomainDiscoveryResults = ds.domainResults
-	ds.Status = CheckStatusComplete
+	if ds.Status != CheckStatusCanceled {
+		ds.Status = CheckStatusComplete
+	}
 	ds.CheckSuite.mu.Unlock()
 
 	// Persist results to history
@@ -1952,9 +1960,7 @@ func (ds *DiscoverySuite) measureNetworkBaseline() float64 {
 		Timeout: timeout,
 		Transport: &http.Transport{
 			TLSClientConfig: ds.tlsConfig(),
-			DialContext: (&net.Dialer{
-				Timeout: timeout / 2,
-			}).DialContext,
+			DialContext:     markedDialer(ds.flowMark, timeout/2, timeout).DialContext,
 		},
 	}
 

--- a/src/discovery/dns.go
+++ b/src/discovery/dns.go
@@ -35,10 +35,11 @@ type CDNEntry struct {
 }
 
 type DNSProber struct {
-	domain  string
-	timeout time.Duration
-	pool    *nfq.Pool
-	cfg     *config.Config
+	domain   string
+	timeout  time.Duration
+	pool     *nfq.Pool
+	cfg      *config.Config
+	flowMark uint
 }
 
 var (
@@ -85,6 +86,7 @@ func (ds *DiscoverySuite) runDNSDiscoveryForDomain(domain string) *DNSDiscoveryR
 		time.Duration(ds.cfg.System.Checker.DiscoveryTimeoutSec)*time.Second,
 		ds.pool,
 		ds.cfg,
+		ds.flowMark,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -129,12 +131,13 @@ func (r *DNSDiscoveryResult) hasWorkingConfig() bool {
 	return !r.IsPoisoned || r.BestServer != "" || r.NeedsFragment
 }
 
-func NewDNSProber(domain string, timeout time.Duration, pool *nfq.Pool, cfg *config.Config) *DNSProber {
+func NewDNSProber(domain string, timeout time.Duration, pool *nfq.Pool, cfg *config.Config, flowMark uint) *DNSProber {
 	return &DNSProber{
-		domain:  domain,
-		timeout: timeout,
-		pool:    pool,
-		cfg:     cfg,
+		domain:   domain,
+		timeout:  timeout,
+		pool:     pool,
+		cfg:      cfg,
+		flowMark: flowMark,
 	}
 }
 
@@ -306,7 +309,8 @@ func (p *DNSProber) getSystemResolverIPs(ctx context.Context) []string {
 		network = "ip6"
 	}
 
-	ips, err := net.DefaultResolver.LookupIP(ctx, network, p.domain)
+	resolver := markedResolver(p.flowMark, p.timeout/2, "")
+	ips, err := resolver.LookupIP(ctx, network, p.domain)
 	if err != nil {
 		log.DiscoveryLogf("  DNS: system resolver error: %v", err)
 		return nil
@@ -342,7 +346,12 @@ func (p *DNSProber) getExpectedIPs(ctx context.Context) []string {
 		"https://cloudflare-dns.com/dns-query?name=%s&type=" + recordType,
 	}
 
-	client := &http.Client{Timeout: p.timeout}
+	client := &http.Client{
+		Timeout: p.timeout,
+		Transport: &http.Transport{
+			DialContext: markedDialer(p.flowMark, p.timeout/2, p.timeout).DialContext,
+		},
+	}
 
 	seenIPs := make(map[string]bool)
 	var allIPs []string
@@ -420,13 +429,7 @@ func (p *DNSProber) getExpectedIPFallback(ctx context.Context) string {
 	}
 
 	for _, server := range p.cfg.System.Checker.ReferenceDNS {
-		resolver := &net.Resolver{
-			PreferGo: true,
-			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-				d := net.Dialer{Timeout: p.timeout / 3}
-				return d.DialContext(ctx, "udp", server+":53")
-			},
-		}
+		resolver := markedResolver(p.flowMark, p.timeout/3, server)
 
 		ips, err := resolver.LookupIP(ctx, network, p.domain)
 		if err == nil && len(ips) > 0 {
@@ -447,15 +450,9 @@ func (p *DNSProber) testDNS(ctx context.Context, server string, fragmented bool,
 		ExpectedIP: expectedIP,
 	}
 
-	resolver := net.DefaultResolver
+	resolver := markedResolver(p.flowMark, p.timeout, "")
 	if server != "" {
-		resolver = &net.Resolver{
-			PreferGo: true,
-			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-				d := net.Dialer{Timeout: p.timeout}
-				return d.DialContext(ctx, network, server+":53")
-			},
-		}
+		resolver = markedResolver(p.flowMark, p.timeout, server)
 	}
 
 	network := "ip4"
@@ -498,7 +495,7 @@ func (p *DNSProber) findValidIP(ctx context.Context, ips []string) string {
 }
 
 func (p *DNSProber) testIPServesDomain(ctx context.Context, ip string) bool {
-	dialer := &net.Dialer{Timeout: p.timeout / 2}
+	dialer := markedDialer(p.flowMark, p.timeout/2, p.timeout)
 	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(ip, "443"))
 	if err != nil {
 		return false
@@ -540,7 +537,8 @@ func (p *DNSProber) testDNSWithFragment(ctx context.Context, server string, expe
 
 	// Now DNS queries should be fragmented via NFQ
 	start := time.Now()
-	ips, err := net.DefaultResolver.LookupIPAddr(lookupCtx, p.domain)
+	resolver := markedResolver(p.flowMark, p.timeout/2, "")
+	ips, err := resolver.LookupIPAddr(lookupCtx, p.domain)
 	result.Latency = time.Since(start)
 
 	if err != nil || len(ips) == 0 {

--- a/src/discovery/runner.go
+++ b/src/discovery/runner.go
@@ -83,8 +83,16 @@ func CancelCheckSuite(id string) error {
 		return nil
 	}
 
-	if suite.Status == CheckStatusRunning {
-		close(suite.cancel)
+	suite.mu.Lock()
+	defer suite.mu.Unlock()
+
+	if suite.Status == CheckStatusPending || suite.Status == CheckStatusRunning {
+		select {
+		case <-suite.cancel:
+			// already canceled
+		default:
+			close(suite.cancel)
+		}
 		suite.Status = CheckStatusCanceled
 	}
 

--- a/src/discovery/runner.go
+++ b/src/discovery/runner.go
@@ -67,6 +67,12 @@ func NewCheckSuite(domainInputs []DomainInput) *CheckSuite {
 	}
 }
 
+func RegisterSuite(suite *CheckSuite) {
+	suitesMu.Lock()
+	activeSuites[suite.Id] = suite
+	suitesMu.Unlock()
+}
+
 func GetCheckSuite(id string) (*CheckSuite, bool) {
 	suitesMu.RLock()
 	defer suitesMu.RUnlock()

--- a/src/discovery/runtime.go
+++ b/src/discovery/runtime.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/daniellavrushin/b4/config"
 	"github.com/daniellavrushin/b4/log"
@@ -83,7 +84,7 @@ func (m *Runtime) Start(cfg *config.Config) (*StartResult, error) {
 
 	pool := nfq.NewPool(discoveryCfg)
 	if err := pool.Start(); err != nil {
-		tables.ClearDiscoverySteeringRules(cfg, flowMark, injectedMark, discoveryStart, discoveryThreads)
+		tables.ClearDiscoverySteeringRules(cfg, flowMark, injectedMark)
 		return nil, fmt.Errorf("failed to start discovery pool: %w", err)
 	}
 
@@ -147,10 +148,16 @@ func (m *Runtime) Stop(cfg *config.Config, suiteID string) {
 		m.mu.Unlock()
 		return
 	}
+	activeSuite := state.activeSuiteID
 	m.state = nil
 	m.mu.Unlock()
 
+	if activeSuite != "" {
+		CancelCheckSuite(activeSuite)
+		time.Sleep(500 * time.Millisecond)
+	}
+
 	state.pool.Stop()
-	tables.ClearDiscoverySteeringRules(cfg, state.discoveryFlowMark, state.discoveryInjMark, state.discoveryStartNum, state.discoveryThreads)
+	tables.ClearDiscoverySteeringRules(cfg, state.discoveryFlowMark, state.discoveryInjMark)
 	log.Infof("Discovery runtime stopped: queue=%d-%d", state.discoveryStartNum, state.discoveryStartNum+state.discoveryThreads-1)
 }

--- a/src/discovery/runtime.go
+++ b/src/discovery/runtime.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -11,6 +12,8 @@ import (
 	"github.com/daniellavrushin/b4/tables"
 )
 
+var ErrDiscoveryAlreadyRunning = errors.New("discovery is already running")
+
 type runtimeState struct {
 	pool              *nfq.Pool
 	discoveryStartNum int
@@ -18,6 +21,7 @@ type runtimeState struct {
 	discoveryFlowMark uint
 	discoveryInjMark  uint
 	activeSuiteID     string
+	stopping          bool
 }
 
 type StartResult struct {
@@ -53,7 +57,7 @@ func (m *Runtime) Start(cfg *config.Config) (*StartResult, error) {
 	defer m.mu.Unlock()
 
 	if m.state != nil {
-		return nil, fmt.Errorf("discovery is already running")
+		return nil, ErrDiscoveryAlreadyRunning
 	}
 
 	mainStart := cfg.Queue.StartNum
@@ -140,7 +144,7 @@ func (m *Runtime) StartSuite(cfg *config.Config, urls []string, opts StartSuiteO
 func (m *Runtime) Stop(cfg *config.Config, suiteID string) {
 	m.mu.Lock()
 	state := m.state
-	if state == nil {
+	if state == nil || state.stopping {
 		m.mu.Unlock()
 		return
 	}
@@ -148,8 +152,8 @@ func (m *Runtime) Stop(cfg *config.Config, suiteID string) {
 		m.mu.Unlock()
 		return
 	}
+	state.stopping = true
 	activeSuite := state.activeSuiteID
-	m.state = nil
 	m.mu.Unlock()
 
 	if activeSuite != "" {
@@ -160,4 +164,8 @@ func (m *Runtime) Stop(cfg *config.Config, suiteID string) {
 	state.pool.Stop()
 	tables.ClearDiscoverySteeringRules(cfg, state.discoveryFlowMark, state.discoveryInjMark)
 	log.Infof("Discovery runtime stopped: queue=%d-%d", state.discoveryStartNum, state.discoveryStartNum+state.discoveryThreads-1)
+
+	m.mu.Lock()
+	m.state = nil
+	m.mu.Unlock()
 }

--- a/src/discovery/runtime.go
+++ b/src/discovery/runtime.go
@@ -131,6 +131,7 @@ func (m *Runtime) StartSuite(cfg *config.Config, urls []string, opts StartSuiteO
 		runtimeState.FlowMark,
 	)
 	m.SetActiveSuiteID(suite.Id)
+	RegisterSuite(suite.CheckSuite)
 
 	go func() {
 		suite.RunDiscovery()

--- a/src/discovery/runtime.go
+++ b/src/discovery/runtime.go
@@ -1,0 +1,156 @@
+package discovery
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/daniellavrushin/b4/config"
+	"github.com/daniellavrushin/b4/log"
+	"github.com/daniellavrushin/b4/nfq"
+	"github.com/daniellavrushin/b4/tables"
+)
+
+type runtimeState struct {
+	pool              *nfq.Pool
+	discoveryStartNum int
+	discoveryThreads  int
+	discoveryFlowMark uint
+	discoveryInjMark  uint
+	activeSuiteID     string
+}
+
+type StartResult struct {
+	Pool     *nfq.Pool
+	FlowMark uint
+}
+
+type StartSuiteOptions struct {
+	SkipDNS         bool
+	SkipCache       bool
+	PayloadFiles    []string
+	ValidationTries int
+	TLSVersion      string
+}
+
+type Runtime struct {
+	mu    sync.Mutex
+	state *runtimeState
+}
+
+func NewRuntime() *Runtime {
+	return &Runtime{}
+}
+
+func (m *Runtime) IsActive() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.state != nil
+}
+
+func (m *Runtime) Start(cfg *config.Config) (*StartResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.state != nil {
+		return nil, fmt.Errorf("discovery is already running")
+	}
+
+	mainStart := cfg.Queue.StartNum
+	mainThreads := cfg.Queue.Threads
+	discoveryThreads := 1
+	discoveryStart := mainStart + mainThreads
+	discoveryEnd := discoveryStart + discoveryThreads - 1
+	if discoveryStart < 0 || discoveryEnd > 65535 {
+		return nil, fmt.Errorf("discovery queue range is out of bounds: %d-%d", discoveryStart, discoveryEnd)
+	}
+
+	flowMark := cfg.DiscoveryFlowMark()
+	injectedMark := cfg.DiscoveryInjectedMark()
+
+	log.Infof("Discovery queue range: main=%d-%d discovery=%d-%d", mainStart, mainStart+mainThreads-1, discoveryStart, discoveryEnd)
+	log.Infof("Discovery marks: main_injected=0x%x discovery_flow=0x%x discovery_injected=0x%x", cfg.MainInjectedMark(), flowMark, injectedMark)
+
+	if err := tables.ApplyDiscoverySteeringRules(cfg, flowMark, injectedMark, discoveryStart, discoveryThreads); err != nil {
+		return nil, fmt.Errorf("failed to apply discovery steering rules: %w", err)
+	}
+
+	discoveryCfg := cfg.Clone()
+	discoveryCfg.Queue.StartNum = discoveryStart
+	discoveryCfg.Queue.Threads = discoveryThreads
+	discoveryCfg.Queue.Mark = injectedMark
+	discoveryCfg.Queue.IsDiscovery = true
+	discoveryCfg.System.Tables.SkipSetup = true
+
+	pool := nfq.NewPool(discoveryCfg)
+	if err := pool.Start(); err != nil {
+		tables.ClearDiscoverySteeringRules(cfg, flowMark, injectedMark, discoveryStart, discoveryThreads)
+		return nil, fmt.Errorf("failed to start discovery pool: %w", err)
+	}
+
+	m.state = &runtimeState{
+		pool:              pool,
+		discoveryStartNum: discoveryStart,
+		discoveryThreads:  discoveryThreads,
+		discoveryFlowMark: flowMark,
+		discoveryInjMark:  injectedMark,
+	}
+
+	return &StartResult{
+		Pool:     pool,
+		FlowMark: flowMark,
+	}, nil
+}
+
+func (m *Runtime) SetActiveSuiteID(suiteID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.state != nil {
+		m.state.activeSuiteID = suiteID
+	}
+}
+
+func (m *Runtime) StartSuite(cfg *config.Config, urls []string, opts StartSuiteOptions) (*DiscoverySuite, error) {
+	runtimeState, err := m.Start(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	suite := NewDiscoverySuite(
+		urls,
+		runtimeState.Pool,
+		opts.SkipDNS,
+		opts.SkipCache,
+		opts.PayloadFiles,
+		opts.ValidationTries,
+		opts.TLSVersion,
+		runtimeState.FlowMark,
+	)
+	m.SetActiveSuiteID(suite.Id)
+
+	go func() {
+		suite.RunDiscovery()
+		log.Infof("Discovery complete for %d domains", len(suite.Domains))
+		m.Stop(cfg, suite.Id)
+	}()
+
+	return suite, nil
+}
+
+func (m *Runtime) Stop(cfg *config.Config, suiteID string) {
+	m.mu.Lock()
+	state := m.state
+	if state == nil {
+		m.mu.Unlock()
+		return
+	}
+	if suiteID != "" && state.activeSuiteID != "" && state.activeSuiteID != suiteID {
+		m.mu.Unlock()
+		return
+	}
+	m.state = nil
+	m.mu.Unlock()
+
+	state.pool.Stop()
+	tables.ClearDiscoverySteeringRules(cfg, state.discoveryFlowMark, state.discoveryInjMark, state.discoveryStartNum, state.discoveryThreads)
+	log.Infof("Discovery runtime stopped: queue=%d-%d", state.discoveryStartNum, state.discoveryStartNum+state.discoveryThreads-1)
+}

--- a/src/discovery/transport.go
+++ b/src/discovery/transport.go
@@ -1,0 +1,48 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func markControl(mark uint) func(string, string, syscall.RawConn) error {
+	return func(_, _ string, c syscall.RawConn) error {
+		var ctrlErr error
+		if err := c.Control(func(fd uintptr) {
+			ctrlErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_MARK, int(mark))
+		}); err != nil {
+			return err
+		}
+		if ctrlErr != nil {
+			return fmt.Errorf("failed to set SO_MARK=%d: %w", mark, ctrlErr)
+		}
+		return nil
+	}
+}
+
+func markedDialer(mark uint, timeout, keepAlive time.Duration) *net.Dialer {
+	return &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: keepAlive,
+		Control:   markControl(mark),
+	}
+}
+
+func markedResolver(mark uint, timeout time.Duration, server string) *net.Resolver {
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			d := markedDialer(mark, timeout, timeout)
+			target := addr
+			if server != "" {
+				target = net.JoinHostPort(server, "53")
+			}
+			return d.DialContext(ctx, network, target)
+		},
+	}
+}

--- a/src/discovery/types.go
+++ b/src/discovery/types.go
@@ -88,7 +88,7 @@ type CheckSuite struct {
 	CurrentDomain          string                            `json:"current_domain,omitempty"`
 	CurrentPhase           DiscoveryPhase                    `json:"current_phase,omitempty"`
 	mu                     sync.RWMutex                      `json:"-"`
-	cancel                 chan struct{}                      `json:"-"`
+	cancel                 chan struct{}                     `json:"-"`
 }
 
 type DomainPresetResult struct {
@@ -171,6 +171,7 @@ type DiscoverySuite struct {
 	skipCache       bool
 	validationTries int
 	tlsVersion      string // "auto", "tls12", "tls13"
+	flowMark        uint
 
 	discoveryCache *DiscoveryCache
 }

--- a/src/http/handler/common.go
+++ b/src/http/handler/common.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/daniellavrushin/b4/config"
+	"github.com/daniellavrushin/b4/discovery"
 	"github.com/daniellavrushin/b4/geodat"
 	"github.com/daniellavrushin/b4/log"
 	"github.com/daniellavrushin/b4/nfq"
@@ -33,6 +34,7 @@ var (
 	globalSocks5Server ConfigRefresher
 	tablesRefreshFunc  func() error
 	routingSyncFunc    func(*config.Config)
+	discoveryRuntime   *discovery.Runtime
 )
 
 func setJsonHeader(w http.ResponseWriter) {
@@ -95,6 +97,7 @@ func NewAPIHandler(cfg *config.Config) *API {
 	return &API{
 		cfg:            cfg,
 		geodataManager: geodataManager,
+		discoveryRT:    discoveryRuntime,
 		deviceAliases:  config.NewDeviceAliases(cfg.ConfigPath),
 		asnStore:       config.NewAsnStore(cfg.ConfigPath),
 	}
@@ -139,6 +142,10 @@ func SetTablesRefreshFunc(fn func() error) {
 
 func SetRoutingSyncFunc(fn func(*config.Config)) {
 	routingSyncFunc = fn
+}
+
+func SetDiscoveryRuntime(rt *discovery.Runtime) {
+	discoveryRuntime = rt
 }
 
 func checkDiskSpace(dir string, needed int64) error {

--- a/src/http/handler/discovery.go
+++ b/src/http/handler/discovery.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -151,7 +152,11 @@ func (api *API) handleStartDiscovery(w http.ResponseWriter, r *http.Request) {
 		TLSVersion:      req.TLSVersion,
 	})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusConflict)
+		if errors.Is(err, discovery.ErrDiscoveryAlreadyRunning) {
+			http.Error(w, err.Error(), http.StatusConflict)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 		return
 	}
 

--- a/src/http/handler/discovery.go
+++ b/src/http/handler/discovery.go
@@ -82,6 +82,9 @@ func (api *API) handleCancelCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Infof("Canceled test suite %s", testID)
+	if api.discoveryRT != nil {
+		api.discoveryRT.Stop(api.cfg, testID)
+	}
 
 	setJsonHeader(w)
 	json.NewEncoder(w).Encode(map[string]interface{}{
@@ -135,14 +138,24 @@ func (api *API) handleStartDiscovery(w http.ResponseWriter, r *http.Request) {
 		validationTries = 1
 	}
 
-	suite := discovery.NewDiscoverySuite(urls, globalPool, req.SkipDNS, req.SkipCache, req.PayloadFiles, validationTries, req.TLSVersion)
+	if api.discoveryRT == nil {
+		http.Error(w, "discovery runtime is not configured", http.StatusInternalServerError)
+		return
+	}
+
+	suite, err := api.discoveryRT.StartSuite(api.cfg, urls, discovery.StartSuiteOptions{
+		SkipDNS:         req.SkipDNS,
+		SkipCache:       req.SkipCache,
+		PayloadFiles:    req.PayloadFiles,
+		ValidationTries: validationTries,
+		TLSVersion:      req.TLSVersion,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
 
 	phase1Count := len(discovery.GetPhase1Presets())
-
-	go func() {
-		suite.RunDiscovery()
-		log.Infof("Discovery complete for %d domains", len(suite.Domains))
-	}()
 
 	var domainNames []string
 	for _, di := range suite.Domains {

--- a/src/http/handler/types.go
+++ b/src/http/handler/types.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/daniellavrushin/b4/config"
+	"github.com/daniellavrushin/b4/discovery"
 	"github.com/daniellavrushin/b4/geodat"
 )
 
@@ -11,6 +12,7 @@ type API struct {
 	cfg            *config.Config
 	mux            *http.ServeMux
 	geodataManager *geodat.GeodataManager
+	discoveryRT    *discovery.Runtime
 	deviceAliases  *config.DeviceAliases
 	asnStore       *config.AsnStore
 

--- a/src/main.go
+++ b/src/main.go
@@ -100,7 +100,17 @@ func runB4(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 		if discoveryRT.IsActive() {
-			return fmt.Errorf("tables refresh is blocked while discovery is running")
+			log.Warnf("Tables refresh requested while discovery is active, waiting for discovery to finish...")
+			deadline := time.After(5 * time.Minute)
+			ticker := time.NewTicker(1 * time.Second)
+			defer ticker.Stop()
+			for discoveryRT.IsActive() {
+				select {
+				case <-deadline:
+					return fmt.Errorf("tables refresh timed out: discovery did not finish within 5 minutes")
+				case <-ticker.C:
+				}
+			}
 		}
 		if err := tables.ClearRules(&cfg); err != nil {
 			return err

--- a/src/main.go
+++ b/src/main.go
@@ -241,10 +241,10 @@ func runB4(cmd *cobra.Command, args []string) error {
 	metrics.RecordEvent("info", fmt.Sprintf("Shutdown initiated by signal: %v", sig))
 
 	// Perform graceful shutdown with timeout
-	return gracefulShutdown(&cfg, pool, httpServer, socks5Server, mtprotoServer, metrics)
+	return gracefulShutdown(&cfg, pool, httpServer, socks5Server, mtprotoServer, metrics, discoveryRT)
 }
 
-func gracefulShutdown(cfg *config.Config, pool *nfq.Pool, httpServer *http.Server, socks5Server *socks5.Server, mtprotoServer *mtproto.Server, metrics *handler.MetricsCollector) error {
+func gracefulShutdown(cfg *config.Config, pool *nfq.Pool, httpServer *http.Server, socks5Server *socks5.Server, mtprotoServer *mtproto.Server, metrics *handler.MetricsCollector, discoveryRT *discovery.Runtime) error {
 	// Create shutdown context with timeout
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -298,6 +298,11 @@ func gracefulShutdown(cfg *config.Config, pool *nfq.Pool, httpServer *http.Serve
 	// Shutdown WebSocket connections
 	log.Infof("Shutting down WebSocket connections...")
 	b4http.Shutdown()
+
+	if discoveryRT != nil && discoveryRT.IsActive() {
+		log.Infof("Stopping active discovery...")
+		discoveryRT.Stop(cfg, "")
+	}
 
 	// Stop NFQueue pool
 	wg.Add(1)

--- a/src/main.go
+++ b/src/main.go
@@ -16,6 +16,7 @@ import (
 	_ "time/tzdata"
 
 	"github.com/daniellavrushin/b4/config"
+	"github.com/daniellavrushin/b4/discovery"
 	b4http "github.com/daniellavrushin/b4/http"
 	"github.com/daniellavrushin/b4/http/handler"
 	"github.com/daniellavrushin/b4/log"
@@ -91,7 +92,28 @@ func runB4(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("verbose") {
 		cfg.ApplyLogLevel(verboseFlag)
 	}
+
+	discoveryRT := discovery.NewRuntime()
+
+	handler.SetTablesRefreshFunc(func() error {
+		if cfg.System.Tables.SkipSetup {
+			return nil
+		}
+		if discoveryRT.IsActive() {
+			return fmt.Errorf("tables refresh is blocked while discovery is running")
+		}
+		if err := tables.ClearRules(&cfg); err != nil {
+			return err
+		}
+		if err := tables.AddRules(&cfg); err != nil {
+			return err
+		}
+		tables.RoutingSyncConfig(&cfg)
+		handler.GetMetricsCollector().TablesStatus = tables.DetectBackend(&cfg)
+		return nil
+	})
 	handler.SetRoutingSyncFunc(tables.RoutingSyncConfig)
+	handler.SetDiscoveryRuntime(discoveryRT)
 	nfq.RoutingHandleDNSFunc = tables.RoutingHandleDNS
 
 	if err := initLogging(&cfg); err != nil {
@@ -143,6 +165,7 @@ func runB4(cmd *cobra.Command, args []string) error {
 			metrics.RecordEvent("error", fmt.Sprintf("Failed to add tables rules: %v", err))
 			return fmt.Errorf("failed to add tables rules: %w", err)
 		}
+		metrics.TablesStatus = tables.DetectBackend(&cfg)
 		metrics.RecordEvent("info", "Tables rules configured successfully")
 	} else {
 		log.Infof("Skipping tables setup (--skip-tables)")
@@ -348,6 +371,8 @@ func gracefulShutdown(cfg *config.Config, pool *nfq.Pool, httpServer *http.Serve
 
 		os.Exit(1)
 	}
+
+	nfq.ShutdownDNSRouteRuntime()
 
 	log.CloseErrorFile()
 	log.Flush()

--- a/src/nfq/connstate.go
+++ b/src/nfq/connstate.go
@@ -27,10 +27,6 @@ type tlsInfoCache struct {
 	conns map[string]*tlsInfo
 }
 
-var tlsCache = &tlsInfoCache{
-	conns: make(map[string]*tlsInfo),
-}
-
 const maxTLSCacheEntries = 20000
 
 func (c *tlsInfoCache) Store(connKey string, host string, tlsVersion uint16) {
@@ -88,11 +84,23 @@ type connStateTracker struct {
 	conns map[string]*connInfo
 }
 
-var connState = &connStateTracker{
-	conns: make(map[string]*connInfo),
+const maxConnStateEntries = 10000
+
+type runtimeState struct {
+	tlsCache  *tlsInfoCache
+	connState *connStateTracker
 }
 
-const maxConnStateEntries = 10000
+func newRuntimeState() *runtimeState {
+	return &runtimeState{
+		tlsCache: &tlsInfoCache{
+			conns: make(map[string]*tlsInfo),
+		},
+		connState: &connStateTracker{
+			conns: make(map[string]*connInfo),
+		},
+	}
+}
 
 func (t *connStateTracker) RegisterOutgoing(connKey string, set *config.SetConfig) {
 	t.mu.Lock()

--- a/src/nfq/dns.go
+++ b/src/nfq/dns.go
@@ -118,7 +118,9 @@ func (w *Worker) processDnsPacket(ipVersion byte, sport uint16, dport uint16, pa
 					originalDst := make(net.IP, 4)
 					copy(originalDst, raw[16:20])
 
-					dns.DnsNATSet(net.IP(raw[12:16]), sport, originalDst)
+					if !cfg.Queue.IsDiscovery {
+						dns.DnsNATSet(net.IP(raw[12:16]), sport, originalDst)
+					}
 
 					copy(raw[16:20], targetDNS)
 					sock.FixIPv4Checksum(raw[:ihl])
@@ -154,7 +156,9 @@ func (w *Worker) processDnsPacket(ipVersion byte, sport uint16, dport uint16, pa
 					originalDst := make(net.IP, 16)
 					copy(originalDst, raw[24:40])
 
-					dns.DnsNATSet(net.IP(raw[8:24]), sport, originalDst)
+					if !cfg.Queue.IsDiscovery {
+						dns.DnsNATSet(net.IP(raw[8:24]), sport, originalDst)
+					}
 
 					copy(raw[24:40], targetDNS)
 					sock.FixUDPChecksumV6(raw)

--- a/src/nfq/dns.go
+++ b/src/nfq/dns.go
@@ -64,7 +64,8 @@ func (w *Worker) processDnsPacket(ipVersion byte, sport uint16, dport uint16, pa
 			domain = strings.ToLower(domain)
 			matcher := w.getMatcher()
 			if matchedSet, set := matcher.MatchSNIWithSource(domain, srcMac); matchedSet {
-				if txidOK && set.Routing.Enabled {
+				cfg := w.getConfig()
+				if txidOK && set.Routing.Enabled && !cfg.Queue.IsDiscovery {
 					var clientIP, dnsServerIP net.IP
 					switch ipVersion {
 					case IPv4:
@@ -197,7 +198,7 @@ func (w *Worker) processDnsPacket(ipVersion byte, sport uint16, dport uint16, pa
 				if ips := dns.ParseResponseIPs(payload); len(ips) > 0 {
 					cfg := w.getConfig()
 					if set := cfg.GetSetById(setID); set != nil {
-						if RoutingHandleDNSFunc != nil {
+						if RoutingHandleDNSFunc != nil && !cfg.Queue.IsDiscovery {
 							RoutingHandleDNSFunc(cfg, set, ips)
 						}
 					}

--- a/src/nfq/dns_routing.go
+++ b/src/nfq/dns_routing.go
@@ -82,11 +82,16 @@ func startDNSRouteCleanup() {
 func stopDNSRouteCleanup() {
 	dnsRouteCleanMu.Lock()
 	defer dnsRouteCleanMu.Unlock()
-	if dnsRouteCleanStop == nil {
-		return
+	if dnsRouteCleanStop != nil {
+		close(dnsRouteCleanStop)
+		dnsRouteCleanStop = nil
 	}
-	close(dnsRouteCleanStop)
-	dnsRouteCleanStop = nil
+}
+
+// ShutdownDNSRouteRuntime stops global DNS-route cleanup goroutine.
+// Call once on process shutdown.
+func ShutdownDNSRouteRuntime() {
+	stopDNSRouteCleanup()
 }
 
 func storeDNSPendingRoute(key string, setID string) {

--- a/src/nfq/handler.go
+++ b/src/nfq/handler.go
@@ -242,7 +242,7 @@ func (w *Worker) handleTCPPacket(q *nfqueue.Nfqueue, id uint32, pkt *pktInfo, cf
 		log.Tracef("TCP duplicate to %s:%d (%d copies, set: %s)", pkt.dstStr, dport, set.TCP.Duplicate.Count, set.Name)
 
 		dupConnKey := fmt.Sprintf(connKeyFormat, pkt.srcStr, sport, pkt.dstStr, dport)
-		dupHost, dupTLS, _ := tlsCache.Lookup(dupConnKey)
+		dupHost, dupTLS, _ := w.tlsCache.Lookup(dupConnKey)
 
 		m := metrics.GetMetricsCollector()
 		m.RecordConnection("TCP-DUP", dupHost, pkt.srcStr, pkt.dstStr, true, pkt.srcMac, set.Name, config.TLSVersionString(dupTLS))
@@ -328,7 +328,7 @@ func (w *Worker) handleTCPPacket(q *nfqueue.Nfqueue, id uint32, pkt *pktInfo, cf
 		host, tlsVersion, _ = sni.ParseTLSClientHelloSNI(payload)
 
 		if host != "" && tlsVersion != 0 {
-			tlsCache.Store(connKey, host, tlsVersion)
+			w.tlsCache.Store(connKey, host, tlsVersion)
 		}
 
 		if captureManager := capture.GetManager(cfg); captureManager != nil {
@@ -363,7 +363,7 @@ func (w *Worker) handleTCPPacket(q *nfqueue.Nfqueue, id uint32, pkt *pktInfo, cf
 
 	if host == "" || tlsVersion == 0 {
 		connKey := fmt.Sprintf(connKeyFormat, pkt.srcStr, sport, pkt.dstStr, dport)
-		if cachedHost, cachedTLS, found := tlsCache.Lookup(connKey); found {
+		if cachedHost, cachedTLS, found := w.tlsCache.Lookup(connKey); found {
 			if host == "" {
 				host = cachedHost
 			}
@@ -396,7 +396,7 @@ func (w *Worker) handleTCPPacket(q *nfqueue.Nfqueue, id uint32, pkt *pktInfo, cf
 	if matched {
 		if set.TCP.Incoming.Mode != config.ConfigOff {
 			connKey := fmt.Sprintf(connKeyFormat, pkt.srcStr, sport, pkt.dstStr, dport)
-			connState.RegisterOutgoing(connKey, set)
+			w.connTracker.RegisterOutgoing(connKey, set)
 		}
 
 		// Routing-only sets should keep original packet path without drop+inject.

--- a/src/nfq/inc.go
+++ b/src/nfq/inc.go
@@ -15,7 +15,7 @@ import (
 var corruptionStrategies = []string{"badsum", "badseq", "badack", "all"}
 
 func (w *Worker) HandleIncoming(q *nfqueue.Nfqueue, id uint32, v byte, raw []byte, ihl int, src net.IP, dstStr string, dport uint16, srcStr string, sport uint16, payload []byte) int {
-	incomingSet := connState.GetSetForIncoming(dstStr, dport, srcStr, sport)
+	incomingSet := w.connTracker.GetSetForIncoming(dstStr, dport, srcStr, sport)
 
 	if incomingSet != nil && incomingSet.TCP.Incoming.Mode != config.ConfigOff {
 		payloadLen := len(payload)
@@ -32,7 +32,7 @@ func (w *Worker) HandleIncoming(q *nfqueue.Nfqueue, id uint32, v byte, raw []byt
 				}
 
 			case "reset":
-				if connState.TrackIncomingBytes(dstStr, dport, srcStr, sport, uint64(payloadLen), inc) {
+				if w.connTracker.TrackIncomingBytes(dstStr, dport, srcStr, sport, uint64(payloadLen), inc) {
 					if v == IPv4 {
 						w.InjectResetIncoming(incomingSet, raw, ihl, src)
 					} else {
@@ -41,7 +41,7 @@ func (w *Worker) HandleIncoming(q *nfqueue.Nfqueue, id uint32, v byte, raw []byt
 				}
 
 			case "fin":
-				if connState.TrackIncomingBytes(dstStr, dport, srcStr, sport, uint64(payloadLen), inc) {
+				if w.connTracker.TrackIncomingBytes(dstStr, dport, srcStr, sport, uint64(payloadLen), inc) {
 					if v == IPv4 {
 						w.InjectFinIncoming(incomingSet, raw, ihl, src)
 					} else {
@@ -50,7 +50,7 @@ func (w *Worker) HandleIncoming(q *nfqueue.Nfqueue, id uint32, v byte, raw []byt
 				}
 
 			case "desync":
-				if connState.TrackIncomingBytes(dstStr, dport, srcStr, sport, uint64(payloadLen), inc) {
+				if w.connTracker.TrackIncomingBytes(dstStr, dport, srcStr, sport, uint64(payloadLen), inc) {
 					if v == IPv4 {
 						w.InjectDesyncIncoming(incomingSet, raw, ihl, src)
 					} else {

--- a/src/nfq/nfq.go
+++ b/src/nfq/nfq.go
@@ -488,7 +488,9 @@ func (w *Worker) gc(cfg *config.Config) {
 		case <-w.ctx.Done():
 			return
 		case <-t.C:
-			connState.Cleanup()
+			if w.connTracker != nil {
+				w.connTracker.Cleanup()
+			}
 			_ = cleanupDNSPendingRoutes(time.Now())
 
 			if cfg.System.WebServer.IsEnabled {

--- a/src/nfq/pool.go
+++ b/src/nfq/pool.go
@@ -36,15 +36,18 @@ func NewPool(cfg *config.Config) *Pool {
 
 	dhcpMgr := dhcp.NewManager()
 
+	state := newRuntimeState()
 	ws := make([]*Worker, 0, threads)
 	for i := 0; i < threads; i++ {
 		w := NewWorkerWithQueue(cfg, start+uint16(i))
 		w.matcher.Store(matcher)
 		w.ipToMac.Store(make(map[string]string))
+		w.tlsCache = state.tlsCache
+		w.connTracker = state.connState
 		ws = append(ws, w)
 	}
 
-	pool := &Pool{Workers: ws, Dhcp: dhcpMgr, stopCleanup: make(chan struct{})}
+	pool := &Pool{Workers: ws, Dhcp: dhcpMgr, stopCleanup: make(chan struct{}), state: state}
 
 	dhcpMgr.OnUpdate(func(ipToMAC map[string]string) {
 		for _, w := range pool.Workers {
@@ -67,8 +70,8 @@ func NewPool(cfg *config.Config) *Pool {
 		for {
 			select {
 			case <-ticker.C:
-				connState.Cleanup()
-				tlsCache.Cleanup()
+				pool.state.connState.Cleanup()
+				pool.state.tlsCache.Cleanup()
 			case <-pool.stopCleanup:
 				return
 			}
@@ -91,9 +94,6 @@ func (p *Pool) Start() error {
 }
 
 func (p *Pool) Stop() {
-	// Stop the DNS routing pending cleanup goroutine
-	stopDNSRouteCleanup()
-
 	// Stop the connState cleanup goroutine
 	select {
 	case <-p.stopCleanup:

--- a/src/nfq/types.go
+++ b/src/nfq/types.go
@@ -46,7 +46,6 @@ type Worker struct {
 	matcher          atomic.Value
 	sock             *sock.Sender
 	ipToMac          atomic.Value
-	connState        sync.Map
 	tlsCache         *tlsInfoCache
 	connTracker      *connStateTracker
 }

--- a/src/nfq/types.go
+++ b/src/nfq/types.go
@@ -20,6 +20,7 @@ type Pool struct {
 	configMu    sync.Mutex
 	Dhcp        *dhcp.Manager
 	stopCleanup chan struct{}
+	state       *runtimeState
 }
 
 type PacketInfo struct {
@@ -46,4 +47,6 @@ type Worker struct {
 	sock             *sock.Sender
 	ipToMac          atomic.Value
 	connState        sync.Map
+	tlsCache         *tlsInfoCache
+	connTracker      *connStateTracker
 }

--- a/src/tables/common.go
+++ b/src/tables/common.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/daniellavrushin/b4/config"
-	"github.com/daniellavrushin/b4/http/handler"
 	"github.com/daniellavrushin/b4/log"
 )
 
@@ -27,15 +26,8 @@ func AddRules(cfg *config.Config) error {
 		return nil
 	}
 
-	handler.SetTablesRefreshFunc(func() error {
-		ClearRules(cfg)
-		return AddRules(cfg)
-	})
-
 	backend := detectFirewallBackend(cfg)
 	log.Tracef("Detected firewall backend: %s", backend)
-	metrics := handler.GetMetricsCollector()
-	metrics.TablesStatus = backend
 
 	if backend == backendNFTables {
 		nft := NewNFTablesManager(cfg)
@@ -58,6 +50,10 @@ func ClearRules(cfg *config.Config) error {
 
 	ipt := NewIPTablesManager(cfg, backend == backendIPTablesLegacy)
 	return ipt.Clear()
+}
+
+func DetectBackend(cfg *config.Config) string {
+	return detectFirewallBackend(cfg)
 }
 
 func run(args ...string) (string, error) {

--- a/src/tables/common.go
+++ b/src/tables/common.go
@@ -40,6 +40,9 @@ func AddRules(cfg *config.Config) error {
 }
 
 func ClearRules(cfg *config.Config) error {
+	if cfg.System.Tables.SkipSetup {
+		return nil
+	}
 
 	backend := detectFirewallBackend(cfg)
 

--- a/src/tables/discovery_ipt.go
+++ b/src/tables/discovery_ipt.go
@@ -65,12 +65,12 @@ func (b *discoveryIptBackend) apply(flowMark uint, injectedMark uint, queueStart
 			return err
 		}
 
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-j", discoveryChainIPT)
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-j", discoveryChainIPT)
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
+		discoveryDelRuleLoop(bin, "OUTPUT", "-j", discoveryChainIPT)
+		discoveryDelRuleLoop(bin, "PREROUTING", "-j", discoveryChainIPT)
+		discoveryDelRuleLoop(bin, "OUTPUT", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
+		discoveryDelRuleLoop(bin, "PREROUTING", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
+		discoveryDelRuleLoop(bin, "OUTPUT", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
+		discoveryDelRuleLoop(bin, "PREROUTING", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
 
 		if _, err := run(bin, "-w", "-t", "mangle", "-I", "OUTPUT", "1", "-j", discoveryChainIPT); err != nil {
 			return err
@@ -103,13 +103,22 @@ func (b *discoveryIptBackend) clear(flowMark uint, injectedMark uint) {
 		flow := fmt.Sprintf("0x%x/0xffffffff", flowMark)
 		injected := fmt.Sprintf("0x%x/0xffffffff", injectedMark)
 
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-j", discoveryChainIPT)
-		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-j", discoveryChainIPT)
+		discoveryDelRuleLoop(bin, "OUTPUT", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
+		discoveryDelRuleLoop(bin, "PREROUTING", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
+		discoveryDelRuleLoop(bin, "OUTPUT", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
+		discoveryDelRuleLoop(bin, "PREROUTING", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
+		discoveryDelRuleLoop(bin, "OUTPUT", "-j", discoveryChainIPT)
+		discoveryDelRuleLoop(bin, "PREROUTING", "-j", discoveryChainIPT)
 		_, _ = run(bin, "-w", "-t", "mangle", "-F", discoveryChainIPT)
 		_, _ = run(bin, "-w", "-t", "mangle", "-X", discoveryChainIPT)
+	}
+}
+
+func discoveryDelRuleLoop(bin string, chain string, ruleArgs ...string) {
+	args := append([]string{bin, "-w", "-t", "mangle", "-D", chain}, ruleArgs...)
+	for range 100 {
+		if _, err := run(args...); err != nil {
+			return
+		}
 	}
 }

--- a/src/tables/discovery_ipt.go
+++ b/src/tables/discovery_ipt.go
@@ -1,0 +1,115 @@
+package tables
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const discoveryChainIPT = "B4_DISCOVERY"
+
+type discoveryIptBackend struct {
+	legacy bool
+}
+
+func (b *discoveryIptBackend) name() string { return b.ipt4() }
+
+func (b *discoveryIptBackend) ipt4() string {
+	if b.legacy {
+		return backendIPTablesLegacy
+	}
+	return backendIPTables
+}
+
+func (b *discoveryIptBackend) ipt6() string {
+	if b.legacy {
+		return backendIP6TablesLegacy
+	}
+	return backendIP6Tables
+}
+
+func (b *discoveryIptBackend) available() bool {
+	return hasBinary(b.ipt4()) || hasBinary(b.ipt6())
+}
+
+func discoveryQueueAction(queueStart int, threads int) []string {
+	if threads > 1 {
+		return []string{"--queue-balance", fmt.Sprintf("%d:%d", queueStart, queueStart+threads-1), "--queue-bypass"}
+	}
+	return []string{"--queue-num", strconv.Itoa(queueStart), "--queue-bypass"}
+}
+
+func (b *discoveryIptBackend) apply(flowMark uint, injectedMark uint, queueStart int, threads int) error {
+	loadKernelModules()
+
+	for _, bin := range []string{b.ipt4(), b.ipt6()} {
+		if !hasBinary(bin) {
+			continue
+		}
+		_, _ = run(bin, "-w", "-t", "mangle", "-N", discoveryChainIPT)
+		_, _ = run(bin, "-w", "-t", "mangle", "-F", discoveryChainIPT)
+
+		flow := fmt.Sprintf("0x%x/0xffffffff", flowMark)
+		injected := fmt.Sprintf("0x%x/0xffffffff", injectedMark)
+		queueSpec := append([]string{bin, "-w", "-t", "mangle", "-A", discoveryChainIPT, "-m", "mark", "--mark", flow, "-j", "NFQUEUE"}, discoveryQueueAction(queueStart, threads)...)
+
+		if _, err := run(bin, "-w", "-t", "mangle", "-A", discoveryChainIPT, "-m", "mark", "--mark", injected, "-j", "ACCEPT"); err != nil {
+			return err
+		}
+		if _, err := run(bin, "-w", "-t", "mangle", "-A", discoveryChainIPT, "-m", "connmark", "--mark", flow, "-j", "MARK", "--set-mark", strconv.FormatUint(uint64(flowMark), 10)); err != nil {
+			return err
+		}
+		if _, err := run(bin, "-w", "-t", "mangle", "-A", discoveryChainIPT, "-m", "mark", "--mark", flow, "-j", "CONNMARK", "--save-mark"); err != nil {
+			return err
+		}
+		if _, err := run(queueSpec...); err != nil {
+			return err
+		}
+
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-j", discoveryChainIPT)
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-j", discoveryChainIPT)
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
+
+		if _, err := run(bin, "-w", "-t", "mangle", "-I", "OUTPUT", "1", "-j", discoveryChainIPT); err != nil {
+			return err
+		}
+		if _, err := run(bin, "-w", "-t", "mangle", "-I", "OUTPUT", "2", "-m", "mark", "--mark", flow, "-j", "ACCEPT"); err != nil {
+			return err
+		}
+		if _, err := run(bin, "-w", "-t", "mangle", "-I", "OUTPUT", "3", "-m", "mark", "--mark", injected, "-j", "ACCEPT"); err != nil {
+			return err
+		}
+		if _, err := run(bin, "-w", "-t", "mangle", "-I", "PREROUTING", "1", "-j", discoveryChainIPT); err != nil {
+			return err
+		}
+		if _, err := run(bin, "-w", "-t", "mangle", "-I", "PREROUTING", "2", "-m", "mark", "--mark", flow, "-j", "ACCEPT"); err != nil {
+			return err
+		}
+		if _, err := run(bin, "-w", "-t", "mangle", "-I", "PREROUTING", "3", "-m", "mark", "--mark", injected, "-j", "ACCEPT"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *discoveryIptBackend) clear(flowMark uint, injectedMark uint) {
+	for _, bin := range []string{b.ipt4(), b.ipt6()} {
+		if !hasBinary(bin) {
+			continue
+		}
+		flow := fmt.Sprintf("0x%x/0xffffffff", flowMark)
+		injected := fmt.Sprintf("0x%x/0xffffffff", injectedMark)
+
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-m", "mark", "--mark", flow, "-j", "ACCEPT")
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-m", "mark", "--mark", injected, "-j", "ACCEPT")
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "OUTPUT", "-j", discoveryChainIPT)
+		_, _ = run(bin, "-w", "-t", "mangle", "-D", "PREROUTING", "-j", discoveryChainIPT)
+		_, _ = run(bin, "-w", "-t", "mangle", "-F", discoveryChainIPT)
+		_, _ = run(bin, "-w", "-t", "mangle", "-X", discoveryChainIPT)
+	}
+}

--- a/src/tables/discovery_nft.go
+++ b/src/tables/discovery_nft.go
@@ -13,8 +13,12 @@ func (b *discoveryNftBackend) name() string    { return backendNFTables }
 func (b *discoveryNftBackend) available() bool { return hasBinary("nft") }
 
 func (b *discoveryNftBackend) apply(flowMark uint, injectedMark uint, queueStart int, threads int) error {
-	_, _ = run("nft", "add", "chain", "inet", nftTableName, discoveryChainNFT)
-	_, _ = run("nft", "flush", "chain", "inet", nftTableName, discoveryChainNFT)
+	if err := runEnsure("nft", "add", "chain", "inet", nftTableName, discoveryChainNFT); err != nil {
+		return fmt.Errorf("failed to create discovery chain: %w", err)
+	}
+	if _, err := run("nft", "flush", "chain", "inet", nftTableName, discoveryChainNFT); err != nil {
+		return fmt.Errorf("failed to flush discovery chain: %w", err)
+	}
 
 	queueExpr := fmt.Sprintf("queue num %d bypass", queueStart)
 	if threads > 1 {
@@ -42,22 +46,22 @@ func (b *discoveryNftBackend) apply(flowMark uint, injectedMark uint, queueStart
 	b.deleteDiscoveryRulesFromChain("output", flowMark, injectedMark)
 	b.deleteDiscoveryRulesFromChain("prerouting", flowMark, injectedMark)
 
-	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "output", "jump", discoveryChainNFT); err != nil {
+	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "output", "meta", "mark", injectedHex, "accept"); err != nil {
 		return err
 	}
 	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "output", "meta", "mark", flowHex, "accept"); err != nil {
 		return err
 	}
-	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "output", "meta", "mark", injectedHex, "accept"); err != nil {
+	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "output", "jump", discoveryChainNFT); err != nil {
 		return err
 	}
-	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "prerouting", "jump", discoveryChainNFT); err != nil {
+	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "prerouting", "meta", "mark", injectedHex, "accept"); err != nil {
 		return err
 	}
 	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "prerouting", "meta", "mark", flowHex, "accept"); err != nil {
 		return err
 	}
-	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "prerouting", "meta", "mark", injectedHex, "accept"); err != nil {
+	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "prerouting", "jump", discoveryChainNFT); err != nil {
 		return err
 	}
 	return nil

--- a/src/tables/discovery_nft.go
+++ b/src/tables/discovery_nft.go
@@ -39,8 +39,8 @@ func (b *discoveryNftBackend) apply(flowMark uint, injectedMark uint, queueStart
 		}
 	}
 
-	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "output", "jump", discoveryChainNFT)
-	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "prerouting", "jump", discoveryChainNFT)
+	b.deleteDiscoveryRulesFromChain("output", flowMark, injectedMark)
+	b.deleteDiscoveryRulesFromChain("prerouting", flowMark, injectedMark)
 
 	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "output", "jump", discoveryChainNFT); err != nil {
 		return err
@@ -64,14 +64,35 @@ func (b *discoveryNftBackend) apply(flowMark uint, injectedMark uint, queueStart
 }
 
 func (b *discoveryNftBackend) clear(flowMark uint, injectedMark uint) {
-	flowHex := fmt.Sprintf("0x%x", flowMark)
-	injectedHex := fmt.Sprintf("0x%x", injectedMark)
-	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "output", "meta", "mark", flowHex, "accept")
-	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "prerouting", "meta", "mark", flowHex, "accept")
-	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "output", "meta", "mark", injectedHex, "accept")
-	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "prerouting", "meta", "mark", injectedHex, "accept")
-	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "output", "jump", discoveryChainNFT)
-	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "prerouting", "jump", discoveryChainNFT)
+	b.deleteDiscoveryRulesFromChain("output", flowMark, injectedMark)
+	b.deleteDiscoveryRulesFromChain("prerouting", flowMark, injectedMark)
 	_, _ = run("nft", "flush", "chain", "inet", nftTableName, discoveryChainNFT)
 	_, _ = run("nft", "delete", "chain", "inet", nftTableName, discoveryChainNFT)
+}
+
+func (b *discoveryNftBackend) deleteDiscoveryRulesFromChain(chain string, flowMark uint, injectedMark uint) {
+	out, err := run("nft", "-a", "list", "chain", "inet", nftTableName, chain)
+	if err != nil {
+		return
+	}
+	flowHex := fmt.Sprintf("0x%08x", flowMark)
+	injectedHex := fmt.Sprintf("0x%08x", injectedMark)
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		isDiscovery := strings.Contains(line, "jump "+discoveryChainNFT) ||
+			(strings.Contains(line, flowHex) && strings.Contains(line, "accept")) ||
+			(strings.Contains(line, injectedHex) && strings.Contains(line, "accept"))
+		if !isDiscovery {
+			continue
+		}
+		idx := strings.Index(line, "# handle ")
+		if idx < 0 {
+			continue
+		}
+		handle := strings.TrimSpace(line[idx+len("# handle "):])
+		if handle == "" {
+			continue
+		}
+		_, _ = run("nft", "delete", "rule", "inet", nftTableName, chain, "handle", handle)
+	}
 }

--- a/src/tables/discovery_nft.go
+++ b/src/tables/discovery_nft.go
@@ -75,13 +75,13 @@ func (b *discoveryNftBackend) deleteDiscoveryRulesFromChain(chain string, flowMa
 	if err != nil {
 		return
 	}
-	flowHex := fmt.Sprintf("0x%08x", flowMark)
-	injectedHex := fmt.Sprintf("0x%08x", injectedMark)
+	flowToken := "mark " + fmt.Sprintf("0x%x", flowMark)
+	injectedToken := "mark " + fmt.Sprintf("0x%x", injectedMark)
 	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimSpace(line)
 		isDiscovery := strings.Contains(line, "jump "+discoveryChainNFT) ||
-			(strings.Contains(line, flowHex) && strings.Contains(line, "accept")) ||
-			(strings.Contains(line, injectedHex) && strings.Contains(line, "accept"))
+			(strings.Contains(line, flowToken) && strings.Contains(line, "accept")) ||
+			(strings.Contains(line, injectedToken) && strings.Contains(line, "accept"))
 		if !isDiscovery {
 			continue
 		}

--- a/src/tables/discovery_nft.go
+++ b/src/tables/discovery_nft.go
@@ -1,0 +1,77 @@
+package tables
+
+import (
+	"fmt"
+	"strings"
+)
+
+const discoveryChainNFT = "b4_discovery"
+
+type discoveryNftBackend struct{}
+
+func (b *discoveryNftBackend) name() string    { return backendNFTables }
+func (b *discoveryNftBackend) available() bool { return hasBinary("nft") }
+
+func (b *discoveryNftBackend) apply(flowMark uint, injectedMark uint, queueStart int, threads int) error {
+	_, _ = run("nft", "add", "chain", "inet", nftTableName, discoveryChainNFT)
+	_, _ = run("nft", "flush", "chain", "inet", nftTableName, discoveryChainNFT)
+
+	queueExpr := fmt.Sprintf("queue num %d bypass", queueStart)
+	if threads > 1 {
+		queueExpr = fmt.Sprintf("queue num %d-%d bypass", queueStart, queueStart+threads-1)
+	}
+
+	flowHex := fmt.Sprintf("0x%x", flowMark)
+	injectedHex := fmt.Sprintf("0x%x", injectedMark)
+	queueTokens := strings.Fields(queueExpr)
+
+	rules := [][]string{
+		{"add", "rule", "inet", nftTableName, discoveryChainNFT, "meta", "mark", injectedHex, "accept"},
+		{"add", "rule", "inet", nftTableName, discoveryChainNFT, "ct", "mark", flowHex, "meta", "mark", "set", "ct", "mark"},
+		{"add", "rule", "inet", nftTableName, discoveryChainNFT, "meta", "mark", flowHex, "ct", "mark", "set", "mark"},
+	}
+	queueRule := append([]string{"add", "rule", "inet", nftTableName, discoveryChainNFT, "meta", "mark", flowHex}, queueTokens...)
+	rules = append(rules, queueRule)
+
+	for _, r := range rules {
+		if _, err := run(append([]string{"nft"}, r...)...); err != nil {
+			return err
+		}
+	}
+
+	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "output", "jump", discoveryChainNFT)
+	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "prerouting", "jump", discoveryChainNFT)
+
+	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "output", "jump", discoveryChainNFT); err != nil {
+		return err
+	}
+	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "output", "meta", "mark", flowHex, "accept"); err != nil {
+		return err
+	}
+	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "output", "meta", "mark", injectedHex, "accept"); err != nil {
+		return err
+	}
+	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "prerouting", "jump", discoveryChainNFT); err != nil {
+		return err
+	}
+	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "prerouting", "meta", "mark", flowHex, "accept"); err != nil {
+		return err
+	}
+	if _, err := run("nft", "insert", "rule", "inet", nftTableName, "prerouting", "meta", "mark", injectedHex, "accept"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *discoveryNftBackend) clear(flowMark uint, injectedMark uint) {
+	flowHex := fmt.Sprintf("0x%x", flowMark)
+	injectedHex := fmt.Sprintf("0x%x", injectedMark)
+	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "output", "meta", "mark", flowHex, "accept")
+	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "prerouting", "meta", "mark", flowHex, "accept")
+	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "output", "meta", "mark", injectedHex, "accept")
+	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "prerouting", "meta", "mark", injectedHex, "accept")
+	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "output", "jump", discoveryChainNFT)
+	_, _ = run("nft", "delete", "rule", "inet", nftTableName, "prerouting", "jump", discoveryChainNFT)
+	_, _ = run("nft", "flush", "chain", "inet", nftTableName, discoveryChainNFT)
+	_, _ = run("nft", "delete", "chain", "inet", nftTableName, discoveryChainNFT)
+}

--- a/src/tables/discovery_rules.go
+++ b/src/tables/discovery_rules.go
@@ -46,9 +46,7 @@ func ApplyDiscoverySteeringRules(cfg *config.Config, flowMark uint, injectedMark
 	return be.apply(flowMark, injectedMark, queueStart, threads)
 }
 
-func ClearDiscoverySteeringRules(cfg *config.Config, flowMark uint, injectedMark uint, queueStart int, threads int) {
-	_ = queueStart
-	_ = threads
+func ClearDiscoverySteeringRules(cfg *config.Config, flowMark uint, injectedMark uint) {
 	be := getDiscoveryBackend(cfg)
 	if be == nil {
 		return

--- a/src/tables/discovery_rules.go
+++ b/src/tables/discovery_rules.go
@@ -1,0 +1,57 @@
+package tables
+
+import (
+	"fmt"
+
+	"github.com/daniellavrushin/b4/config"
+)
+
+type discoveryBackend interface {
+	name() string
+	available() bool
+	apply(flowMark uint, injectedMark uint, queueStart int, threads int) error
+	clear(flowMark uint, injectedMark uint)
+}
+
+func getDiscoveryBackend(cfg *config.Config) discoveryBackend {
+	backend := detectFirewallBackend(cfg)
+	nft := &discoveryNftBackend{}
+	ipt := &discoveryIptBackend{legacy: backend == backendIPTablesLegacy}
+
+	switch backend {
+	case backendNFTables:
+		if nft.available() {
+			return nft
+		}
+	default:
+		if ipt.available() {
+			return ipt
+		}
+	}
+
+	if nft.available() {
+		return nft
+	}
+	if ipt.available() {
+		return ipt
+	}
+	return nil
+}
+
+func ApplyDiscoverySteeringRules(cfg *config.Config, flowMark uint, injectedMark uint, queueStart int, threads int) error {
+	be := getDiscoveryBackend(cfg)
+	if be == nil {
+		return fmt.Errorf("no discovery firewall backend available")
+	}
+	return be.apply(flowMark, injectedMark, queueStart, threads)
+}
+
+func ClearDiscoverySteeringRules(cfg *config.Config, flowMark uint, injectedMark uint, queueStart int, threads int) {
+	_ = queueStart
+	_ = threads
+	be := getDiscoveryBackend(cfg)
+	if be == nil {
+		return
+	}
+	be.clear(flowMark, injectedMark)
+}

--- a/src/tables/tables_test.go
+++ b/src/tables/tables_test.go
@@ -1,6 +1,7 @@
 package tables
 
 import (
+	"net"
 	"testing"
 
 	"github.com/daniellavrushin/b4/config"
@@ -437,6 +438,472 @@ func TestChunkPorts(t *testing.T) {
 			t.Errorf("chunk should be empty, got %d", len(chunks[0]))
 		}
 	})
+}
+
+func TestRouteSanitizeSetID(t *testing.T) {
+	t.Run("alphanumeric passthrough", func(t *testing.T) {
+		result := routeSanitizeSetID("mySet1")
+		if len(result) == 0 {
+			t.Fatal("expected non-empty result")
+		}
+		if result[:6] != "myset1" {
+			t.Errorf("expected prefix 'myset1', got %q", result)
+		}
+	})
+
+	t.Run("special chars stripped", func(t *testing.T) {
+		result := routeSanitizeSetID("my-Set!@#2")
+		if len(result) == 0 {
+			t.Fatal("expected non-empty result")
+		}
+		for _, c := range result {
+			if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') {
+				t.Errorf("unexpected char %c in sanitized ID", c)
+			}
+		}
+	})
+
+	t.Run("empty input returns default with suffix", func(t *testing.T) {
+		result := routeSanitizeSetID("")
+		if len(result) == 0 {
+			t.Fatal("expected non-empty result")
+		}
+		if result[:7] != "default" {
+			t.Errorf("expected 'default' prefix, got %q", result)
+		}
+	})
+
+	t.Run("truncated to 20 chars", func(t *testing.T) {
+		result := routeSanitizeSetID("abcdefghijklmnopqrstuvwxyz0123456789")
+		if len(result) > 20 {
+			t.Errorf("expected max 20 chars, got %d: %q", len(result), result)
+		}
+	})
+
+	t.Run("deterministic", func(t *testing.T) {
+		a := routeSanitizeSetID("test_set")
+		b := routeSanitizeSetID("test_set")
+		if a != b {
+			t.Errorf("expected deterministic output, got %q and %q", a, b)
+		}
+	})
+
+	t.Run("different inputs produce different outputs", func(t *testing.T) {
+		a := routeSanitizeSetID("set_a")
+		b := routeSanitizeSetID("set_b")
+		if a == b {
+			t.Errorf("expected different outputs for different inputs, both got %q", a)
+		}
+	})
+}
+
+func TestRouteBuildSetNames(t *testing.T) {
+	v4, v6 := routeBuildSetNames("test")
+	if v4 == "" || v6 == "" {
+		t.Fatal("expected non-empty set names")
+	}
+	if v4[len(v4)-3:] != "_v4" {
+		t.Errorf("v4 set should end with '_v4', got %q", v4)
+	}
+	if v6[len(v6)-3:] != "_v6" {
+		t.Errorf("v6 set should end with '_v6', got %q", v6)
+	}
+	if v4[:4] != "b4r_" {
+		t.Errorf("v4 set should start with 'b4r_', got %q", v4)
+	}
+}
+
+func TestRouteBuildChainNames(t *testing.T) {
+	pre, out, nat := routeBuildChainNames("test")
+	if pre == "" || out == "" || nat == "" {
+		t.Fatal("expected non-empty chain names")
+	}
+	if pre[len(pre)-4:] != "_pre" {
+		t.Errorf("pre chain should end with '_pre', got %q", pre)
+	}
+	if out[len(out)-4:] != "_out" {
+		t.Errorf("out chain should end with '_out', got %q", out)
+	}
+	if nat[len(nat)-4:] != "_nat" {
+		t.Errorf("nat chain should end with '_nat', got %q", nat)
+	}
+}
+
+func TestRouteNormalizedSources(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		result := routeNormalizedSources(nil)
+		if result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		result := routeNormalizedSources([]string{})
+		if result != nil {
+			t.Errorf("expected nil, got %v", result)
+		}
+	})
+
+	t.Run("deduplication", func(t *testing.T) {
+		result := routeNormalizedSources([]string{"eth0", "eth1", "eth0"})
+		if len(result) != 2 {
+			t.Fatalf("expected 2, got %d: %v", len(result), result)
+		}
+	})
+
+	t.Run("sorted output", func(t *testing.T) {
+		result := routeNormalizedSources([]string{"wlan0", "eth0", "br0"})
+		if result[0] != "br0" || result[1] != "eth0" || result[2] != "wlan0" {
+			t.Errorf("expected sorted, got %v", result)
+		}
+	})
+
+	t.Run("whitespace trimmed", func(t *testing.T) {
+		result := routeNormalizedSources([]string{" eth0 ", "", "  "})
+		if len(result) != 1 || result[0] != "eth0" {
+			t.Errorf("expected [eth0], got %v", result)
+		}
+	})
+}
+
+func TestRouteQueueBypassMark(t *testing.T) {
+	t.Run("nil config", func(t *testing.T) {
+		if got := routeQueueBypassMark(nil); got != 0x8000 {
+			t.Errorf("expected 0x8000, got 0x%x", got)
+		}
+	})
+
+	t.Run("zero mark uses default", func(t *testing.T) {
+		cfg := config.NewConfig()
+		cfg.Queue.Mark = 0
+		if got := routeQueueBypassMark(&cfg); got != 0x8000 {
+			t.Errorf("expected 0x8000, got 0x%x", got)
+		}
+	})
+
+	t.Run("custom mark", func(t *testing.T) {
+		cfg := config.NewConfig()
+		cfg.Queue.Mark = 0x1234
+		if got := routeQueueBypassMark(&cfg); got != 0x1234 {
+			t.Errorf("expected 0x1234, got 0x%x", got)
+		}
+	})
+}
+
+func TestRouteCollectEntries(t *testing.T) {
+	t.Run("nil set", func(t *testing.T) {
+		v4, v6 := routeCollectEntries(nil)
+		if v4 != nil || v6 != nil {
+			t.Error("expected nil for nil set")
+		}
+	})
+
+	t.Run("empty IPs", func(t *testing.T) {
+		set := &config.SetConfig{}
+		v4, v6 := routeCollectEntries(set)
+		if v4 != nil || v6 != nil {
+			t.Error("expected nil for empty IPs")
+		}
+	})
+
+	t.Run("IPv4 addresses", func(t *testing.T) {
+		set := &config.SetConfig{}
+		set.Targets.IpsToMatch = []string{"1.2.3.4", "5.6.7.8"}
+		v4, v6 := routeCollectEntries(set)
+		if len(v4) != 2 {
+			t.Errorf("expected 2 v4, got %d", len(v4))
+		}
+		if len(v6) != 0 {
+			t.Errorf("expected 0 v6, got %d", len(v6))
+		}
+	})
+
+	t.Run("IPv6 addresses", func(t *testing.T) {
+		set := &config.SetConfig{}
+		set.Targets.IpsToMatch = []string{"2001:db8::1", "fe80::1"}
+		v4, v6 := routeCollectEntries(set)
+		if len(v4) != 0 {
+			t.Errorf("expected 0 v4, got %d", len(v4))
+		}
+		if len(v6) != 2 {
+			t.Errorf("expected 2 v6, got %d", len(v6))
+		}
+	})
+
+	t.Run("CIDR notation", func(t *testing.T) {
+		set := &config.SetConfig{}
+		set.Targets.IpsToMatch = []string{"10.0.0.0/24", "2001:db8::/32"}
+		v4, v6 := routeCollectEntries(set)
+		if len(v4) != 1 {
+			t.Errorf("expected 1 v4, got %d", len(v4))
+		}
+		if len(v6) != 1 {
+			t.Errorf("expected 1 v6, got %d", len(v6))
+		}
+	})
+
+	t.Run("deduplication", func(t *testing.T) {
+		set := &config.SetConfig{}
+		set.Targets.IpsToMatch = []string{"1.2.3.4", "1.2.3.4", "1.2.3.4"}
+		v4, _ := routeCollectEntries(set)
+		if len(v4) != 1 {
+			t.Errorf("expected 1 deduplicated, got %d", len(v4))
+		}
+	})
+
+	t.Run("invalid entries skipped", func(t *testing.T) {
+		set := &config.SetConfig{}
+		set.Targets.IpsToMatch = []string{"not-an-ip", "", "  ", "1.2.3.4"}
+		v4, v6 := routeCollectEntries(set)
+		if len(v4) != 1 {
+			t.Errorf("expected 1 v4, got %d", len(v4))
+		}
+		if len(v6) != 0 {
+			t.Errorf("expected 0 v6, got %d", len(v6))
+		}
+	})
+
+	t.Run("mixed v4 and v6", func(t *testing.T) {
+		set := &config.SetConfig{}
+		set.Targets.IpsToMatch = []string{"1.2.3.4", "2001:db8::1", "10.0.0.1"}
+		v4, v6 := routeCollectEntries(set)
+		if len(v4) != 2 {
+			t.Errorf("expected 2 v4, got %d", len(v4))
+		}
+		if len(v6) != 1 {
+			t.Errorf("expected 1 v6, got %d", len(v6))
+		}
+	})
+}
+
+func TestRouteResolveIDs(t *testing.T) {
+	origCache := routeRuleCache
+	origAuto := routeIfaceAuto
+	defer func() {
+		routeRuleCache = origCache
+		routeIfaceAuto = origAuto
+	}()
+
+	t.Run("explicit mark and table", func(t *testing.T) {
+		routeRuleCache = make(map[string]routeState)
+		routeIfaceAuto = make(map[string]routeState)
+
+		cfg := config.NewConfig()
+		set := &config.SetConfig{}
+		set.Routing.FWMark = 0x100
+		set.Routing.Table = 200
+		set.Routing.EgressInterface = "eth0"
+
+		mark, table := routeResolveIDs(&cfg, set)
+		if mark != 0x100 || table != 200 {
+			t.Errorf("expected mark=0x100 table=200, got mark=0x%x table=%d", mark, table)
+		}
+	})
+
+	t.Run("auto allocation deterministic per interface", func(t *testing.T) {
+		routeRuleCache = make(map[string]routeState)
+		routeIfaceAuto = make(map[string]routeState)
+
+		cfg := config.NewConfig()
+		set := &config.SetConfig{}
+		set.Routing.EgressInterface = "wg0"
+
+		mark1, table1 := routeResolveIDs(&cfg, set)
+		if mark1 == 0 || table1 == 0 {
+			t.Fatalf("expected non-zero, got mark=0x%x table=%d", mark1, table1)
+		}
+
+		routeRuleCache = make(map[string]routeState)
+		routeIfaceAuto = make(map[string]routeState)
+		mark2, table2 := routeResolveIDs(&cfg, set)
+		if mark1 != mark2 || table1 != table2 {
+			t.Errorf("expected deterministic: mark1=0x%x mark2=0x%x table1=%d table2=%d", mark1, mark2, table1, table2)
+		}
+	})
+
+	t.Run("reuses cached iface auto", func(t *testing.T) {
+		routeRuleCache = make(map[string]routeState)
+		routeIfaceAuto = map[string]routeState{
+			"tun0": {mark: 0x555, table: 150},
+		}
+
+		cfg := config.NewConfig()
+		set := &config.SetConfig{}
+		set.Routing.EgressInterface = "tun0"
+
+		mark, table := routeResolveIDs(&cfg, set)
+		if mark != 0x555 || table != 150 {
+			t.Errorf("expected cached mark=0x555 table=150, got mark=0x%x table=%d", mark, table)
+		}
+	})
+
+	t.Run("different interfaces get different IDs", func(t *testing.T) {
+		routeRuleCache = make(map[string]routeState)
+		routeIfaceAuto = make(map[string]routeState)
+
+		cfg := config.NewConfig()
+		setA := &config.SetConfig{}
+		setA.Routing.EgressInterface = "eth0"
+		setB := &config.SetConfig{}
+		setB.Routing.EgressInterface = "wg0"
+
+		markA, tableA := routeResolveIDs(&cfg, setA)
+		markB, tableB := routeResolveIDs(&cfg, setB)
+		if markA == markB {
+			t.Errorf("expected different marks, both got 0x%x", markA)
+		}
+		if tableA == tableB {
+			t.Errorf("expected different tables, both got %d", tableA)
+		}
+	})
+}
+
+func TestRouteAddIPsToSets(t *testing.T) {
+	t.Run("classifies v4 and v6", func(t *testing.T) {
+		var v4calls, v6calls [][]string
+		mock := &mockRouteBackend{
+			addElementsFn: func(setName string, ips []string, ttl int) {
+				if setName == "set_v4" {
+					v4calls = append(v4calls, ips)
+				} else {
+					v6calls = append(v6calls, ips)
+				}
+			},
+		}
+		st := routeState{setV4: "set_v4", setV6: "set_v6"}
+		ips := []net.IP{
+			net.ParseIP("1.2.3.4"),
+			net.ParseIP("2001:db8::1"),
+			net.ParseIP("5.6.7.8"),
+		}
+		routeAddIPsToSets(mock, st, 3600, ips, true, true)
+		if len(v4calls) != 1 || len(v4calls[0]) != 2 {
+			t.Errorf("expected 2 v4 IPs in 1 call, got %v", v4calls)
+		}
+		if len(v6calls) != 1 || len(v6calls[0]) != 1 {
+			t.Errorf("expected 1 v6 IP in 1 call, got %v", v6calls)
+		}
+	})
+
+	t.Run("skips v4 when disabled", func(t *testing.T) {
+		calls := 0
+		mock := &mockRouteBackend{
+			addElementsFn: func(setName string, ips []string, ttl int) { calls++ },
+		}
+		st := routeState{setV4: "set_v4", setV6: "set_v6"}
+		ips := []net.IP{net.ParseIP("1.2.3.4")}
+		routeAddIPsToSets(mock, st, 3600, ips, false, true)
+		if calls != 0 {
+			t.Errorf("expected 0 calls when v4 disabled, got %d", calls)
+		}
+	})
+
+	t.Run("deduplicates IPs", func(t *testing.T) {
+		var gotIPs []string
+		mock := &mockRouteBackend{
+			addElementsFn: func(setName string, ips []string, ttl int) { gotIPs = ips },
+		}
+		st := routeState{setV4: "set_v4", setV6: "set_v6"}
+		ips := []net.IP{
+			net.ParseIP("1.2.3.4"),
+			net.ParseIP("1.2.3.4"),
+			net.ParseIP("1.2.3.4"),
+		}
+		routeAddIPsToSets(mock, st, 3600, ips, true, true)
+		if len(gotIPs) != 1 {
+			t.Errorf("expected 1 deduplicated IP, got %d", len(gotIPs))
+		}
+	})
+}
+
+func TestDiscoveryQueueAction(t *testing.T) {
+	t.Run("single thread", func(t *testing.T) {
+		action := discoveryQueueAction(200, 1)
+		if len(action) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(action))
+		}
+		if action[0] != "--queue-num" || action[1] != "200" || action[2] != "--queue-bypass" {
+			t.Errorf("unexpected action: %v", action)
+		}
+	})
+
+	t.Run("multiple threads", func(t *testing.T) {
+		action := discoveryQueueAction(200, 4)
+		if len(action) != 3 {
+			t.Fatalf("expected 3 elements, got %d", len(action))
+		}
+		if action[0] != "--queue-balance" || action[1] != "200:203" || action[2] != "--queue-bypass" {
+			t.Errorf("unexpected action: %v", action)
+		}
+	})
+}
+
+func TestDiscoveryIptBackend_BinaryNames(t *testing.T) {
+	t.Run("standard", func(t *testing.T) {
+		b := &discoveryIptBackend{legacy: false}
+		if b.ipt4() != backendIPTables {
+			t.Errorf("expected %s, got %s", backendIPTables, b.ipt4())
+		}
+		if b.ipt6() != backendIP6Tables {
+			t.Errorf("expected %s, got %s", backendIP6Tables, b.ipt6())
+		}
+		if b.name() != backendIPTables {
+			t.Errorf("expected %s, got %s", backendIPTables, b.name())
+		}
+	})
+
+	t.Run("legacy", func(t *testing.T) {
+		b := &discoveryIptBackend{legacy: true}
+		if b.ipt4() != backendIPTablesLegacy {
+			t.Errorf("expected %s, got %s", backendIPTablesLegacy, b.ipt4())
+		}
+		if b.ipt6() != backendIP6TablesLegacy {
+			t.Errorf("expected %s, got %s", backendIP6TablesLegacy, b.ipt6())
+		}
+	})
+}
+
+func TestDiscoveryNftBackend_Name(t *testing.T) {
+	b := &discoveryNftBackend{}
+	if b.name() != backendNFTables {
+		t.Errorf("expected %s, got %s", backendNFTables, b.name())
+	}
+}
+
+func TestDiscoveryConstants(t *testing.T) {
+	if discoveryChainIPT != "B4_DISCOVERY" {
+		t.Errorf("discoveryChainIPT = %q, want B4_DISCOVERY", discoveryChainIPT)
+	}
+	if discoveryChainNFT != "b4_discovery" {
+		t.Errorf("discoveryChainNFT = %q, want b4_discovery", discoveryChainNFT)
+	}
+}
+
+type mockRouteBackend struct {
+	addElementsFn func(setName string, ips []string, ttlSec int)
+}
+
+func (m *mockRouteBackend) name() string                                          { return "mock" }
+func (m *mockRouteBackend) available() bool                                       { return true }
+func (m *mockRouteBackend) ensureBase() error                                     { return nil }
+func (m *mockRouteBackend) ensureIPSet(name string, v6 bool) error                { return nil }
+func (m *mockRouteBackend) ensureChain(chain string, isMangle bool) error         { return nil }
+func (m *mockRouteBackend) flushChain(chain string, isMangle bool)                {}
+func (m *mockRouteBackend) deleteChain(chain string, isMangle bool)               {}
+func (m *mockRouteBackend) addBypassRule(chain string, mark uint32)               {}
+func (m *mockRouteBackend) addMarkRule(chain string, v6 bool, setName string, mark uint32, sourceIface string, tagHostConntrack bool) {
+}
+func (m *mockRouteBackend) ensureJumpRule(baseChain, targetChain string, isMangle bool)  {}
+func (m *mockRouteBackend) deleteJumpRules(baseChain, targetChain string, isMangle bool) {}
+func (m *mockRouteBackend) addMasqueradeRule(chain string, mark uint32, iface string, v6 bool) {
+}
+func (m *mockRouteBackend) flushIPSet(name string)   {}
+func (m *mockRouteBackend) destroyIPSet(name string) {}
+func (m *mockRouteBackend) clearAll()                {}
+func (m *mockRouteBackend) addElements(setName string, ips []string, ttlSec int) {
+	if m.addElementsFn != nil {
+		m.addElementsFn(setName, ips, ttlSec)
+	}
 }
 
 func TestMonitor_BackendPropagation(t *testing.T) {


### PR DESCRIPTION
- Introduced a dedicated discovery.Runtime singleton (created in main) to manage discovery lifecycle.
- Discovery now runs on an isolated NFQUEUE pool with separate steering rules, without mutating main runtime sets.
- Removed `tables -> handler` dependency; moved tables refresh wiring and backend metrics updates to main.
- Added fail-fast protection: tables soft-refresh is blocked while discovery is active.
- Fixed discovery cancellation flow: supports pending, uses safe cancel channel handling, and preserves canceled status.