### PR TITLE
Add PREROUTING DNS request queue rules for local DNS proxy setups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # B4 - Bye Bye Big Bro
 
+## [1.48.2] - 2026-04-07
+
+- FIXED: **GeoSite routing not working with encrypted DNS** — when using DoH/DoT (e.g. `https-dns-proxy`), domains from `GeoSite` categories were not added to routing sets. B4 now intercepts DNS queries earlier so routing works regardless of how upstream DNS is configured.
+
 ## [1.48.1] - 2026-04-05
 
 - ADDED: **UDP Reject mode** — new option for QUIC/UDP handling that sends an ICMP "Port Unreachable" response instead of silently dropping packets. Clients fall back to TCP almost instantly instead of waiting for timeouts.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## [1.48.2] - 2026-04-07
 
-- FIXED: **GeoSite routing not working with encrypted DNS** — when using DoH/DoT (e.g. `https-dns-proxy`), domains from `GeoSite` categories were not added to routing sets. B4 now intercepts DNS queries earlier so routing works regardless of how upstream DNS is configured.
+- FIXED: **GeoSite routing not working with local DNS proxies** — when the router forwards DNS through a local proxy like `https-dns-proxy`, domains from `GeoSite` categories were not added to routing sets. B4 now intercepts DNS queries earlier so routing works in these setups.
 
 ## [1.48.1] - 2026-04-05
 

--- a/src/nfq/dns.go
+++ b/src/nfq/dns.go
@@ -9,6 +9,7 @@ import (
 	"github.com/daniellavrushin/b4/dns"
 	"github.com/daniellavrushin/b4/log"
 	"github.com/daniellavrushin/b4/sock"
+	"github.com/daniellavrushin/b4/utils"
 	"github.com/florianl/go-nfqueue"
 )
 
@@ -91,7 +92,20 @@ func (w *Worker) processDnsPacket(ipVersion byte, sport uint16, dport uint16, pa
 						}
 					}
 				}
-				if !(set.DNS.Enabled && set.DNS.TargetDNS != "") {
+				dnsRedirect := set.DNS.Enabled && set.DNS.TargetDNS != ""
+				if dnsRedirect {
+					var dstIP net.IP
+					switch ipVersion {
+					case IPv4:
+						dstIP = net.IP(raw[16:20])
+					case IPv6:
+						dstIP = net.IP(raw[24:40])
+					}
+					if dstIP != nil && utils.IsPrivateIP(dstIP) {
+						dnsRedirect = false
+					}
+				}
+				if !dnsRedirect {
 					if err := w.q.SetVerdict(id, nfqueue.NfAccept); err != nil {
 						log.Tracef("failed to set verdict on packet %d: %v", id, err)
 					}

--- a/src/tables/iptables.go
+++ b/src/tables/iptables.go
@@ -417,6 +417,7 @@ func (manager *IPTablesManager) buildManifest() (Manifest, error) {
 		}
 
 		rules = append(rules,
+			Rule{manager: manager, IPT: ipt, Table: "mangle", Chain: "PREROUTING", Action: "I", Spec: dnsSpec},
 			Rule{manager: manager, IPT: ipt, Table: "mangle", Chain: "PREROUTING", Action: "I", Spec: dnsResponseSpec},
 		)
 

--- a/src/tables/monitor.go
+++ b/src/tables/monitor.go
@@ -30,7 +30,8 @@ type ifaceSnapshot struct {
 }
 
 var (
-	dnsPortMatch = "sport 53"
+	dnsResponsePortMatch = "sport 53"
+	dnsRequestPortMatch  = "dport 53"
 )
 
 func NewMonitor(cfgPtr *atomic.Pointer[config.Config]) *Monitor {
@@ -154,10 +155,11 @@ func (m *Monitor) checkIPTablesRules(cfg *config.Config) bool {
 		}
 
 		out, _ := run(ipt, "-w", "-t", "mangle", "-S", "PREROUTING")
-		hasDNS := strings.Contains(out, dnsPortMatch) && strings.Contains(out, "NFQUEUE")
+		hasDNSResponse := strings.Contains(out, dnsResponsePortMatch) && strings.Contains(out, "NFQUEUE")
+		hasDNSRequest := strings.Contains(out, dnsRequestPortMatch) && strings.Contains(out, "NFQUEUE")
 		hasTCP := strings.Contains(out, "tcp") && strings.Contains(out, "NFQUEUE")
-		if !hasDNS || !hasTCP {
-			log.Tracef("Monitor: PREROUTING response rules missing (dns=%v, tcp=%v)", hasDNS, hasTCP)
+		if !hasDNSResponse || !hasDNSRequest || !hasTCP {
+			log.Tracef("Monitor: PREROUTING rules missing (dnsReq=%v, dnsResp=%v, tcp=%v)", hasDNSRequest, hasDNSResponse, hasTCP)
 			return false
 		}
 
@@ -167,7 +169,7 @@ func (m *Monitor) checkIPTablesRules(cfg *config.Config) bool {
 		}
 
 		out, _ = run(ipt, "-w", "-t", "mangle", "-S", "OUTPUT")
-		if !strings.Contains(out, dnsPortMatch) || !strings.Contains(out, "NFQUEUE") {
+		if !strings.Contains(out, dnsResponsePortMatch) || !strings.Contains(out, "NFQUEUE") {
 			log.Tracef("Monitor: OUTPUT DNS response rule missing")
 			return false
 		}
@@ -243,10 +245,11 @@ func (m *Monitor) checkNFTablesRules(cfg *config.Config) bool {
 		return false
 	}
 	out, _ := nft.runNft("list", "chain", "inet", nftTableName, "prerouting")
-	hasDNS := strings.Contains(out, dnsPortMatch) && strings.Contains(out, "queue")
+	hasDNSResponse := strings.Contains(out, dnsResponsePortMatch) && strings.Contains(out, "queue")
+	hasDNSRequest := strings.Contains(out, dnsRequestPortMatch) && strings.Contains(out, "queue")
 	hasTCP := strings.Contains(out, "tcp sport") && strings.Contains(out, "queue")
-	if !hasDNS || !hasTCP {
-		log.Tracef("Monitor: prerouting response rules missing (dns=%v, tcp=%v)", hasDNS, hasTCP)
+	if !hasDNSResponse || !hasDNSRequest || !hasTCP {
+		log.Tracef("Monitor: prerouting rules missing (dnsReq=%v, dnsResp=%v, tcp=%v)", hasDNSRequest, hasDNSResponse, hasTCP)
 		return false
 	}
 
@@ -256,7 +259,7 @@ func (m *Monitor) checkNFTablesRules(cfg *config.Config) bool {
 	}
 
 	out, _ = nft.runNft("list", "chain", "inet", nftTableName, "output")
-	if !strings.Contains(out, dnsPortMatch) || !strings.Contains(out, "queue") {
+	if !strings.Contains(out, dnsResponsePortMatch) || !strings.Contains(out, "queue") {
 		log.Tracef("Monitor: output DNS response rule missing")
 		return false
 	}

--- a/src/tables/nftables.go
+++ b/src/tables/nftables.go
@@ -287,6 +287,10 @@ func (n *NFTablesManager) Apply() error {
 		return err
 	}
 
+	if err := n.addQueueRule("prerouting", "udp", "dport", "53", "counter"); err != nil {
+		return err
+	}
+
 	if err := n.addQueueRule("prerouting", "udp", "sport", "53", "counter"); err != nil {
 		return err
 	}


### PR DESCRIPTION
This is an attempt to fix issue https://github.com/DanielLavrushin/b4/issues/181.

In local DNS proxy topologies (for example, router-side `dnsmasq` forwarding to `https-dns-proxy`), DNS traffic flow differs from plain upstream UDP/53 resolution. Because of that, b4 may fail to correlate DNS requests and responses, which prevents resolved IPs from being learned for routing sets.

This change adds DNS request capture in `PREROUTING` for destination port 53, so b4 can learn request context earlier on the LAN->router path and correctly match corresponding DNS responses. As a result, resolved addresses should be added to routing sets more reliably in setups using local DNS proxy chains.