### PR TITLE
Update config.go

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -235,7 +235,7 @@ var DefaultConfig = Config{
 		},
 
 		Logging: Logging{
-			Level:      log.LevelInfo,
+			Level:      log.LevelError,
 			Instaflush: true,
 			Syslog:     false,
 			ErrorFile:  "/var/log/b4/errors.log",


### PR DESCRIPTION
Измененее дефолтного логирования на LevelError
логирование выше ошибок очень "шумное" и нужно только для отладки. при перезапуске сервиса уровень логирование не грузиться из конфигаа. проще поменять дефолтное. логирование в файл или syslog особо кретично для устройств использующие флеш накопители. проверил. с данным фиксом syslog не захломляется.  для примера, по данным дашборды, 
Uptime: 13h 46m 41s
Connections 415.0K