### PR TITLE
fix: improve single-instance check to prevent false "another b4 insta…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # B4 - Bye Bye Big Bro
 
+## [1.61.4] - 2026-05-10
+
+- FIXED: **False "another b4 instance is already running" error** - b4 could refuse to start after a crash, after restarting from the Web UI, or when running inside containers (for example on MikroTik), even when no other b4 was actually running. The single-instance check is now reliable in those cases.
+
 ## [1.61.3] - 2026-05-09
 
 - ADDED: **Custom payload for UDP fake packets** - new "Fake Packet Payload" picker in the UDP fake settings of each set. Choose a captured `.bin` (uploaded in Settings → Payloads, or auto-captured from live QUIC traffic) to use as the body of fake UDP packets. Empty = zero fill (previous behavior). The Settings → Payloads upload form now has an explicit TLS/QUIC protocol selector.

--- a/src/main.go
+++ b/src/main.go
@@ -455,11 +455,11 @@ func gracefulShutdown(cfg *config.Config, pool *nfq.Pool, httpServer *http.Serve
 }
 
 func ensureSingleInstance() (func(), error) {
-	candidates := []string{"/var/run/b4.pid", "/run/b4.pid", "/tmp/b4.pid"}
+	candidates := []string{"/var/run/b4.pid", "/run/b4.pid"}
 	var f *os.File
 	var path string
 	for _, p := range candidates {
-		fp, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0644)
+		fp, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0600)
 		if err == nil {
 			f = fp
 			path = p
@@ -485,10 +485,9 @@ func ensureSingleInstance() (func(), error) {
 		return nil, fmt.Errorf("another b4 instance is already running (pid %s)", pid)
 	}
 
-	f.Truncate(0)
-	f.Seek(0, 0)
-	fmt.Fprintf(f, "%d\n", os.Getpid())
-	f.Sync()
+	if err := writePidFile(f, os.Getpid()); err != nil {
+		fmt.Fprintf(os.Stderr, "[INIT] could not update pidfile %s: %v\n", path, err)
+	}
 
 	cleanup := func() {
 		syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
@@ -496,6 +495,19 @@ func ensureSingleInstance() (func(), error) {
 		os.Remove(path)
 	}
 	return cleanup, nil
+}
+
+func writePidFile(f *os.File, pid int) error {
+	if err := f.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "%d\n", pid); err != nil {
+		return err
+	}
+	return f.Sync()
 }
 
 func initMemoryLimit() {

--- a/src/main.go
+++ b/src/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 	"os/signal"
 	"runtime/debug"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -87,8 +87,12 @@ func runB4(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if err := ensureSingleInstance(); err != nil {
+	releaseLock, err := ensureSingleInstance()
+	if err != nil {
 		return err
+	}
+	if releaseLock != nil {
+		defer releaseLock()
 	}
 
 	initTimezone()
@@ -450,39 +454,48 @@ func gracefulShutdown(cfg *config.Config, pool *nfq.Pool, httpServer *http.Serve
 	return nil
 }
 
-func ensureSingleInstance() error {
-	self := os.Getpid()
-	selfComm, err := os.ReadFile("/proc/self/comm")
-	if err != nil {
-		return nil
+func ensureSingleInstance() (func(), error) {
+	candidates := []string{"/var/run/b4.pid", "/run/b4.pid", "/tmp/b4.pid"}
+	var f *os.File
+	var path string
+	for _, p := range candidates {
+		fp, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0644)
+		if err == nil {
+			f = fp
+			path = p
+			break
+		}
 	}
-	target := strings.TrimSpace(string(selfComm))
-	if target == "" {
-		return nil
+	if f == nil {
+		return nil, nil
 	}
 
-	entries, err := os.ReadDir("/proc")
-	if err != nil {
-		return nil
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			fmt.Fprintf(os.Stderr, "[INIT] single-instance check skipped: flock(%s): %v\n", path, err)
+			f.Close()
+			return nil, nil
+		}
+		data, _ := io.ReadAll(f)
+		pid := strings.TrimSpace(string(data))
+		f.Close()
+		if pid == "" {
+			return nil, fmt.Errorf("another b4 instance is already running (lock: %s)", path)
+		}
+		return nil, fmt.Errorf("another b4 instance is already running (pid %s)", pid)
 	}
 
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		pid, err := strconv.Atoi(e.Name())
-		if err != nil || pid == self {
-			continue
-		}
-		data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-		if err != nil {
-			continue
-		}
-		if strings.TrimSpace(string(data)) == target {
-			return fmt.Errorf("another b4 instance is already running (pid %d)", pid)
-		}
+	f.Truncate(0)
+	f.Seek(0, 0)
+	fmt.Fprintf(f, "%d\n", os.Getpid())
+	f.Sync()
+
+	cleanup := func() {
+		syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		f.Close()
+		os.Remove(path)
 	}
-	return nil
+	return cleanup, nil
 }
 
 func initMemoryLimit() {


### PR DESCRIPTION
This pull request addresses a critical bug in the application's single-instance check mechanism, ensuring that only one instance of the application runs at a time. The previous approach could falsely detect another instance as running, especially after a crash or restart, leading to startup failures. The new implementation uses file locking for reliable detection and cleanup.

**Bug fix: Reliable single-instance enforcement**

* Improved the single-instance check by replacing the old `/proc`-based process scanning with a file lock (`flock`) mechanism on a PID file (tries `/var/run/b4.pid`, `/run/b4.pid`, `/tmp/b4.pid`). This prevents false positives after crashes, restarts, or in containerized environments, and ensures proper cleanup of the lock file. (`src/main.go`) [[1]](diffhunk://#diff-9e185f29fa355d7dd8fdd9c9ff1d0723b85206aa7d37c4eec93997005dc291ebL90-R96) [[2]](diffhunk://#diff-9e185f29fa355d7dd8fdd9c9ff1d0723b85206aa7d37c4eec93997005dc291ebL453-R498)
* Updated the changelog to document the fix for the false "another b4 instance is already running" error. (`changelog.md`)

**Dependency and import updates**

* Added the `errors` package import to support improved error handling in the new single-instance logic. (`src/main.go`)