### PR TITLE
issue-260

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -214,7 +214,7 @@ detect_architecture() {
     armv7 | armv7l)
         if [ -f /proc/cpuinfo ] &&
             grep -qE "(vfpv[3-9])" /proc/cpuinfo 2>/dev/null &&
-            grep -qE "CPU architecture:\s*7" /proc/cpuinfo 2>/dev/null; then
+            grep -qE "CPU architecture:[[:space:]]*7" /proc/cpuinfo 2>/dev/null; then
             echo "armv7"
         else
             echo "armv5"
@@ -224,9 +224,9 @@ detect_architecture() {
     armv5*) echo "armv5" ;;
     arm*)
         if [ -f /proc/cpuinfo ]; then
-            if grep -qE "CPU architecture:\s*7" /proc/cpuinfo 2>/dev/null; then
+            if grep -qE "CPU architecture:[[:space:]]*7" /proc/cpuinfo 2>/dev/null; then
                 echo "armv7"
-            elif grep -qE "CPU architecture:\s*6" /proc/cpuinfo 2>/dev/null; then
+            elif grep -qE "CPU architecture:[[:space:]]*6" /proc/cpuinfo 2>/dev/null; then
                 echo "armv6"
             else
                 echo "armv5"

--- a/installer/lib/utils.sh
+++ b/installer/lib/utils.sh
@@ -156,7 +156,7 @@ detect_architecture() {
         # Check for full ARMv7 VFP support, otherwise use armv5 for safety
         if [ -f /proc/cpuinfo ] &&
             grep -qE "(vfpv[3-9])" /proc/cpuinfo 2>/dev/null &&
-            grep -qE "CPU architecture:\s*7" /proc/cpuinfo 2>/dev/null; then
+            grep -qE "CPU architecture:[[:space:]]*7" /proc/cpuinfo 2>/dev/null; then
             echo "armv7"
         else
             echo "armv5"
@@ -166,9 +166,9 @@ detect_architecture() {
     armv5*) echo "armv5" ;;
     arm*)
         if [ -f /proc/cpuinfo ]; then
-            if grep -qE "CPU architecture:\s*7" /proc/cpuinfo 2>/dev/null; then
+            if grep -qE "CPU architecture:[[:space:]]*7" /proc/cpuinfo 2>/dev/null; then
                 echo "armv7"
-            elif grep -qE "CPU architecture:\s*6" /proc/cpuinfo 2>/dev/null; then
+            elif grep -qE "CPU architecture:[[:space:]]*6" /proc/cpuinfo 2>/dev/null; then
                 echo "armv6"
             else
                 echo "armv5"


### PR DESCRIPTION
This pull request updates the way ARM CPU architectures are detected in both `install.sh` and `installer/lib/utils.sh`. The main improvement is standardizing the regular expressions used to match the CPU architecture version in `/proc/cpuinfo`, making them more robust and portable by using `[[:space:]]*` instead of `\s*`.
issue #260 

**ARM architecture detection improvements:**

* Updated all `grep` regular expressions that match `"CPU architecture:\s*7"` and `"CPU architecture:\s*6"` to use the more portable POSIX character class `[[:space:]]*` instead of `\s*` in both `install.sh` and `installer/lib/utils.sh`. This change ensures better compatibility across different `grep` implementations and environments. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL217-R217) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL227-R229) [[3]](diffhunk://#diff-a354be6d23f387755459dac599b78da5924e0740c4a66f353f50b249353c9162L159-R159) [[4]](diffhunk://#diff-a354be6d23f387755459dac599b78da5924e0740c4a66f353f50b249353c9162L169-R171)